### PR TITLE
Add e2e Github action

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,0 +1,28 @@
+name: Run e2e
+on:
+  - workflow_dispatch
+  - schedule:
+    - cron: "0 7 * * *"
+  - push:
+      branches: [main]
+
+permissions:
+      id-token: write
+      contents: read
+
+jobs: 
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: hashicorp/setup-terraform@v1
+
+      - name: "Azure login"
+        uses: azure/login@v1
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_E2E_SUBSCRIPTION_ID }}
+
+      - name: "Provision infrastructure"
+        run: "make dev"

--- a/devenv/main.tf
+++ b/devenv/main.tf
@@ -12,6 +12,8 @@ resource "random_string" "random" {
   special = false
 }
 
+resource "time_static" "provisiontime" {}
+
 variable "example_ingress_domain" {
   default = "ingress.dev"
 }
@@ -27,8 +29,12 @@ data "azurerm_subscription" "current" {
 }
 
 resource "azurerm_resource_group" "rg" {
-  name     = "app-routing-dev-${substr(sha256(data.azurerm_client_config.current.client_id), 1, 8)}"
+  name     = "app-routing-dev-${random_string.random.result}a"
   location = "South Central US"
+  tags = {
+    deletion_due_time  = time_static.provisiontime.unix + 36000, // keep resources for 10hr
+    deletion_marked_by = "gc",
+  }
 }
 
 resource "azurerm_kubernetes_cluster" "cluster" {
@@ -42,7 +48,7 @@ resource "azurerm_kubernetes_cluster" "cluster" {
   default_node_pool {
     name       = "default"
     node_count = 2
-    vm_size    = "Standard_D2_v2"
+    vm_size    = "Standard_DS2_v2"
   }
 
   identity {


### PR DESCRIPTION
Switches the devenv to use a random resource group name, adds garbage collection tags, and adds a simple GH action to provision a dev env every night. 

Eventually this action will also run some e2e tests.