### PR TITLE
Add some simple e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
+.PHONY: dev clean e2e
+
 dev:
 	cd devenv && mkdir -p state && terraform init && terraform apply -auto-approve
 
 clean:
 	rm -rf devenv/state devenv/.terraform.lock.hcl devenv/.terraform devenv/terraform.tfstate devenv/terraform.tfstate.backup
 
+e2e:
+	go test -v --count=1 --tags=e2e ./e2e

--- a/devenv/main.tf
+++ b/devenv/main.tf
@@ -190,3 +190,20 @@ resource "local_file" "envscript" {
   EOF
   filename = "${path.module}/state/env.sh"
 }
+
+resource "local_file" "e2econf" {
+  content = jsonencode({
+    MSIClientID       = data.azurerm_user_assigned_identity.clusteridentity.client_id
+    TenantID          = data.azurerm_client_config.current.tenant_id
+    Location          = azurerm_resource_group.rg.location
+    DNSZoneRG         = azurerm_dns_zone.dnszone.resource_group_name
+    DNSZoneSub        = data.azurerm_subscription.current.subscription_id
+    DNSZoneDomain     = var.example_ingress_domain
+    CertHostname      = var.example_ingress_host
+    TestNamservers    = azurerm_dns_zone.dnszone.name_servers
+    Kubeconfig        = "${abspath(path.module)}/state/kubeconfig"
+    CertID            = azurerm_key_vault_certificate.testcert.id
+    CertVersionlessID = azurerm_key_vault_certificate.testcert.versionless_id
+  })
+  filename = "${path.module}/state/e2e.json"
+}

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -72,7 +72,9 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func TestBasicNginx(t *testing.T) {
+// TestBasicService is the most common user scenario - add annotations to a service, get back working
+// ingress with TLS termination and e2e encryption using OSM.
+func TestBasicService(t *testing.T) {
 	suite.StartTestCase(t).
 		WithResources(
 			fixtures.NewClientDeployment(t, conf.CertHostname, conf.TestNamservers),
@@ -80,7 +82,17 @@ func TestBasicNginx(t *testing.T) {
 			fixtures.NewService("server", conf.CertHostname, conf.CertID, 8080))
 }
 
-func TestBasicNginxNoOSM(t *testing.T) {
+// TestBasicServiceVersionlessCert proves that users can remove the version hash from a Keyvault cert URI.
+func TestBasicServiceVersionlessCert(t *testing.T) {
+	suite.StartTestCase(t).
+		WithResources(
+			fixtures.NewClientDeployment(t, conf.CertHostname, conf.TestNamservers),
+			fixtures.NewGoDeployment(t, "server"),
+			fixtures.NewService("server", conf.CertHostname, conf.CertVersionlessID, 8080))
+}
+
+// TestBasicServiceNoOSM is identical to TestBasicService but disables OSM.
+func TestBasicServiceNoOSM(t *testing.T) {
 	svc := fixtures.NewService("server", conf.CertHostname, conf.CertID, 8080)
 	svc.Annotations["kubernetes.azure.com/insecure-disable-osm"] = "true"
 

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -1,0 +1,94 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/Azure/aks-app-routing-operator/e2e/e2eutil"
+	"github.com/Azure/aks-app-routing-operator/e2e/fixtures"
+	"github.com/Azure/aks-app-routing-operator/pkg/config"
+	"github.com/Azure/aks-app-routing-operator/pkg/controller"
+	"github.com/Azure/aks-app-routing-operator/pkg/util"
+)
+
+var (
+	suite e2eutil.Suite
+	conf  = &testConfig{Config: config.Flags}
+)
+
+type testConfig struct {
+	*config.Config
+	CertHostname              string
+	TestNamservers            []string
+	Kubeconfig                string
+	CertID, CertVersionlessID string
+}
+
+func TestMain(m *testing.M) {
+	// Load configuration
+	rawConf, err := ioutil.ReadFile("../devenv/state/e2e.json")
+	if err != nil {
+		panic(err)
+	}
+	if err := json.Unmarshal(rawConf, conf); err != nil {
+		panic(err)
+	}
+	if err := conf.Validate(); err != nil {
+		panic(err)
+	}
+	rc, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		&clientcmd.ClientConfigLoadingRules{ExplicitPath: conf.Kubeconfig},
+		&clientcmd.ConfigOverrides{}).ClientConfig()
+	if err != nil {
+		panic(err)
+	}
+	util.UseServerSideApply()
+	suite.Clientset, err = kubernetes.NewForConfig(rc)
+	if err != nil {
+		panic(err)
+	}
+
+	// Start controllers
+	manager, err := controller.NewManagerForRestConfig(config.Flags, rc)
+	if err != nil {
+		panic(err)
+	}
+	suite.Client = manager.GetClient()
+	go manager.Start(context.Background())
+
+	// Run tests
+	suite.Purge()
+	os.Exit(m.Run())
+}
+
+func TestBasicNginx(t *testing.T) {
+	suite.StartTestCase(t).
+		WithResources(
+			fixtures.NewClientDeployment(t, conf.CertHostname, conf.TestNamservers),
+			fixtures.NewGoDeployment(t, "server"),
+			fixtures.NewService("server", conf.CertHostname, conf.CertID, 8080))
+}
+
+func TestBasicNginxNoOSM(t *testing.T) {
+	svc := fixtures.NewService("server", conf.CertHostname, conf.CertID, 8080)
+	svc.Annotations["kubernetes.azure.com/insecure-disable-osm"] = "true"
+
+	svr := fixtures.NewGoDeployment(t, "server")
+	svr.Spec.Template.Annotations["openservicemesh.io/sidecar-injection"] = "disabled"
+
+	suite.StartTestCase(t).
+		WithResources(
+			fixtures.NewClientDeployment(t, conf.CertHostname, conf.TestNamservers),
+			svr, svc)
+}

--- a/e2e/e2eutil/e2eutil.go
+++ b/e2e/e2eutil/e2eutil.go
@@ -1,0 +1,162 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package e2eutil
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/Azure/aks-app-routing-operator/pkg/util"
+)
+
+type Suite struct {
+	Client    client.Client
+	Clientset kubernetes.Interface
+}
+
+func (s *Suite) StartTestCase(t *testing.T) *Case {
+	return &Case{Suite: s, t: t}
+}
+
+// Purge cleans up resources created by the previous run.
+func (s *Suite) Purge() {
+	list, err := s.Clientset.CoreV1().Namespaces().List(context.Background(), metav1.ListOptions{
+		LabelSelector: "app.kubernetes.io/managed-by=e2eutil",
+	})
+	if err != nil {
+		fmt.Printf("error while listing namespaces to purge past test runs: %s\n", err)
+		return
+	}
+	for _, item := range list.Items {
+		fmt.Printf("cleaning up namespace from previous run %q\n", item.Name)
+		err = s.Clientset.CoreV1().Namespaces().Delete(context.Background(), item.Name, metav1.DeleteOptions{})
+		if err != nil {
+			fmt.Printf("error while cleaning up namespace %q: %s\n", item.Name, err)
+		}
+	}
+}
+
+type Case struct {
+	*Suite
+	t  *testing.T
+	ns string
+}
+
+func (c *Case) Retry(fn func() error) {
+	c.t.Helper()
+	for {
+		err := fn()
+		if err == nil {
+			return
+		}
+		c.t.Logf("error: %s", err)
+		time.Sleep(util.Jitter(time.Millisecond*200, 0.5))
+	}
+}
+
+// WithResources creates Kubernetes resources for the test case and waits for them to become ready.
+func (c *Case) WithResources(resources ...client.Object) {
+	c.ensureNS()
+	var wg sync.WaitGroup
+	for _, res := range resources {
+		res.SetNamespace(c.ns)
+		c.Retry(func() error {
+			return c.Client.Create(context.Background(), res)
+		})
+
+		wg.Add(1)
+		go func(res interface{}) {
+			defer wg.Done()
+			switch obj := res.(type) {
+			case *appsv1.Deployment:
+				c.watchDeployment(obj)
+			}
+		}(res)
+	}
+	wg.Wait()
+}
+
+func (c *Case) watchDeployment(obj *appsv1.Deployment) {
+	c.Retry(func() error {
+		watch, err := c.Clientset.AppsV1().Deployments(c.ns).Watch(context.Background(), metav1.ListOptions{
+			FieldSelector:   "metadata.name=" + obj.Name,
+			ResourceVersion: obj.ResourceVersion,
+		})
+		if err != nil {
+			return err
+		}
+		c.t.Cleanup(watch.Stop)
+		for event := range watch.ResultChan() {
+			item, ok := event.Object.(*appsv1.Deployment)
+			if !ok {
+				return fmt.Errorf("unknown event type: %T", event.Object)
+			}
+			if item.Status.ReadyReplicas == *item.Spec.Replicas {
+				break
+			}
+		}
+		return nil
+	})
+}
+
+func (c *Case) ensureNS() {
+	if c.ns != "" {
+		return
+	}
+
+	c.Retry(func() error {
+		ns := &corev1.Namespace{}
+		ns.GenerateName = "e2e-" + strings.ToLower(c.t.Name()) + "-"
+		ns.Labels = map[string]string{"app.kubernetes.io/managed-by": "e2eutil", "openservicemesh.io/monitored-by": "osm"}
+		ns.Annotations = map[string]string{"openservicemesh.io/sidecar-injection": "enabled"}
+		ns, err := c.Clientset.CoreV1().Namespaces().Create(context.Background(), ns, metav1.CreateOptions{})
+		c.ns = ns.Name
+		return err
+	})
+
+	// Log events in the namespace
+	go func() {
+		c.Retry(func() error {
+			watch, err := c.Clientset.CoreV1().Events(c.ns).Watch(context.Background(), metav1.ListOptions{})
+			if err != nil {
+				return err
+			}
+			c.t.Cleanup(watch.Stop)
+			for msg := range watch.ResultChan() {
+				event, ok := msg.Object.(*corev1.Event)
+				if !ok {
+					return fmt.Errorf("unknown event type: %T", msg.Object)
+				}
+				log.Printf("k8s event: (%s %s) %s %s - %s", event.InvolvedObject.Kind, event.InvolvedObject.Name, event.Kind, event.Reason, event.Message)
+
+				// Print pod logs if they crash or fail readiness probes
+				probeFailed := strings.Contains(event.Message, "Readiness probe failed")
+				containerCrashed := event.Message == "Back-off restarting failed container"
+				if !containerCrashed && !probeFailed {
+					continue
+				}
+				logs, err := c.Clientset.CoreV1().Pods(c.ns).
+					GetLogs(event.InvolvedObject.Name, &corev1.PodLogOptions{Previous: containerCrashed, Container: "container", TailLines: util.Int64Ptr(3)}).
+					DoRaw(context.Background())
+				if err != nil {
+					log.Printf("error while getting pod logs: %s", err)
+					continue
+				}
+				log.Printf("log from pod %s:\n%s", event.InvolvedObject.Name, logs)
+			}
+			return nil
+		})
+	}()
+}

--- a/e2e/fixtures/client/main.go
+++ b/e2e/fixtures/client/main.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"io/ioutil"
+	"log"
+	"math/rand"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+func main() {
+	nameservers := strings.Split(os.Getenv("NAMESERVERS"), ",")
+	rand.Seed(time.Now().Unix())
+
+	dialer := &net.Dialer{Resolver: &net.Resolver{
+		PreferGo: true,
+		Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+			d := net.Dialer{Timeout: time.Second}
+			ns := nameservers[rand.Intn(len(nameservers)-1)]
+			ns = ns[:len(ns)-1] // remove trailing period added for some reason by azure dns
+			return d.DialContext(ctx, "tcp", ns+":53")
+		},
+	}}
+	client := &http.Client{Transport: &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		DialContext:     dialer.DialContext,
+	}}
+
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		resp, err := client.Get(os.Getenv("URL"))
+		if err != nil {
+			log.Printf("error sending request: %s", err)
+			w.WriteHeader(500)
+			return
+		}
+		defer resp.Body.Close()
+
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			log.Printf("error reading response body: %s", err)
+			w.WriteHeader(500)
+			return
+		}
+		if string(body) != "hello world" {
+			log.Printf("unexpected response body: %s", body)
+			w.WriteHeader(500)
+			return
+		}
+		if val := resp.Header.Get("TestHeader"); val != "test-header-value" {
+			log.Printf("unexpected test header: %s", val)
+			w.WriteHeader(500)
+			return
+		}
+		if val := resp.Header.Get("OriginalForwardedFor"); val != os.Getenv("POD_IP") {
+			log.Printf("server replied with unexpected X-Forwarded-For header: %s", val)
+			w.WriteHeader(500)
+			return
+		}
+	})
+	panic(http.ListenAndServe(":8080", nil))
+}

--- a/e2e/fixtures/fixtures.go
+++ b/e2e/fixtures/fixtures.go
@@ -1,0 +1,100 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package fixtures
+
+import (
+	"os"
+	"path"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/Azure/aks-app-routing-operator/pkg/util"
+)
+
+func NewClientDeployment(t *testing.T, host string, nameservers []string) *appsv1.Deployment {
+	deploy := NewGoDeployment(t, "client")
+	deploy.Spec.Template.Annotations["openservicemesh.io/sidecar-injection"] = "disabled"
+	deploy.Spec.Template.Spec.Containers[0].Env = []corev1.EnvVar{{
+		Name:  "URL",
+		Value: "https://" + host,
+	}, {
+		Name:  "NAMESERVERS",
+		Value: strings.Join(nameservers, ","),
+	}, {
+		Name:      "POD_IP",
+		ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.podIP"}},
+	}}
+	deploy.Spec.Template.Spec.Containers[0].ReadinessProbe = &corev1.Probe{
+		FailureThreshold:    1,
+		InitialDelaySeconds: 1,
+		PeriodSeconds:       1,
+		SuccessThreshold:    1,
+		TimeoutSeconds:      5,
+		ProbeHandler: corev1.ProbeHandler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Path:   "/",
+				Port:   intstr.FromInt(8080),
+				Scheme: corev1.URISchemeHTTP,
+			},
+		},
+	}
+	return deploy
+}
+
+func NewGoDeployment(t testing.TB, name string) *appsv1.Deployment {
+	source, err := os.ReadFile(path.Join("fixtures", name, "main.go"))
+	require.NoError(t, err)
+
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: util.Int32Ptr(1),
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": name}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels:      map[string]string{"app": name},
+					Annotations: map[string]string{},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "container",
+						Image: "mcr.microsoft.com/oss/go/microsoft/golang:1.18",
+						Command: []string{
+							"/bin/sh",
+							"-c",
+							"mkdir source && cd source && go mod init source && echo '" + string(source) + "' > main.go && go run main.go",
+						},
+					}},
+				},
+			},
+		},
+	}
+}
+
+func NewService(app, host, keyvaultURI string, port int32) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: app,
+			Annotations: map[string]string{
+				"kubernetes.azure.com/ingress-host":          host,
+				"kubernetes.azure.com/tls-cert-keyvault-uri": keyvaultURI,
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{{
+				Name: "http",
+				Port: port,
+			}},
+			Selector: map[string]string{"app": app},
+		},
+	}
+}

--- a/e2e/fixtures/server/main.go
+++ b/e2e/fixtures/server/main.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"net/http"
+)
+
+func main() {
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("TestHeader", "test-header-value")
+		w.Header().Set("OriginalForwardedFor", r.Header.Get("X-Forwarded-For"))
+		w.Write([]byte("hello world"))
+	})
+	panic(http.ListenAndServe(":8080", nil))
+}


### PR DESCRIPTION
Adds a library to help manage k8s resources in an e2e testing workflow, and a few simple e2e test cases to cover common scenarios.

We can expand this later, but for now it at least provides a fast sanity check while developing the codebase.