### PR TITLE
Expose some options as CLI flags

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -25,9 +25,14 @@ func init() {
 	flag.Float64Var(&Flags.ConcurrencyWatchdogThres, "concurrency-watchdog-threshold", 200, "percentage of concurrent connections above mean required to vote for load shedding")
 	flag.IntVar(&Flags.ConcurrencyWatchdogVotes, "concurrency-watchdog-votes", 4, "number of votes required for a pod to be considered for load shedding")
 	flag.BoolVar(&Flags.DisableOSM, "disable-osm", false, "enable Open Service Mesh integration")
+	flag.StringVar(&Flags.ServiceAccountTokenPath, "service-account-token-path", "", "optionally override the default token path")
+	flag.StringVar(&Flags.MetricsAddr, "metrics-addr", "0.0.0.0:8081", "address to serve Prometheus metrics on")
+	flag.StringVar(&Flags.ProbeAddr, "probe-addr", "0.0.0.0:8080", "address to serve readiness/liveness probes on")
 }
 
 type Config struct {
+	ServiceAccountTokenPath                           string
+	MetricsAddr, ProbeAddr                            string
 	NS, Registry                                      string
 	DisableKeyvault                                   bool
 	MSIClientID, TenantID                             string


### PR DESCRIPTION
The service account token flag is required to use projected service account tokens that have an `exp` claim (unlike injected sa tokens).