### PR TITLE
Add RBAC role manifest

### DIFF
--- a/e2e/e2eutil/e2eutil.go
+++ b/e2e/e2eutil/e2eutil.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -15,6 +16,9 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/yaml"
+	applymetav1 "k8s.io/client-go/applyconfigurations/meta/v1"
+	rbacv1 "k8s.io/client-go/applyconfigurations/rbac/v1"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -159,4 +163,40 @@ func (c *Case) ensureNS() {
 			return nil
 		})
 	}()
+}
+
+// SetupRBAC creates and binds a ClusterRole manifest to a given username. Intended to be used
+// by e2e tests that need to limit their own k8s access.
+func SetupRBAC(cs kubernetes.Interface, roleManifestPath, userName string) error {
+	role := &rbacv1.ClusterRoleApplyConfiguration{}
+	rawRole, err := os.ReadFile(roleManifestPath)
+	if err != nil {
+		return err
+	}
+	if err := yaml.Unmarshal(rawRole, role); err != nil {
+		return err
+	}
+	_, err = cs.RbacV1().ClusterRoles().Apply(context.Background(), role, metav1.ApplyOptions{FieldManager: "e2e"})
+	if err != nil {
+		return err
+	}
+
+	roleBinding := &rbacv1.ClusterRoleBindingApplyConfiguration{
+		ObjectMetaApplyConfiguration: &applymetav1.ObjectMetaApplyConfiguration{
+			Name: role.Name,
+		},
+		Subjects: []rbacv1.SubjectApplyConfiguration{{
+			Kind: util.StringPtr("User"),
+			Name: util.StringPtr(userName),
+		}},
+		RoleRef: &rbacv1.RoleRefApplyConfiguration{
+			Kind:     util.StringPtr("ClusterRole"),
+			Name:     role.Name,
+			APIGroup: util.StringPtr("rbac.authorization.k8s.io"),
+		},
+	}
+	roleBinding.Kind = util.StringPtr("ClusterRoleBinding")
+	roleBinding.APIVersion = util.StringPtr("rbac.authorization.k8s.io/v1")
+	_, err = cs.RbacV1().ClusterRoleBindings().Apply(context.Background(), roleBinding, metav1.ApplyOptions{FieldManager: "e2e"})
+	return err
 }

--- a/rbac.yaml
+++ b/rbac.yaml
@@ -1,0 +1,47 @@
+# This file contains a minimal cluster role for the operator.
+# It's tested as part of the operator's e2e tests, so it can be trusted to provide sufficient privileges.
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: aks-app-routing-operator
+rules:
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["clusterrolebindings", "clusterroles"]
+    verbs: ["*"]
+
+  - apiGroups: [""]
+    resources: ["namespaces", "configmaps", "services", "events", "serviceaccounts"]
+    verbs: ["*"]
+
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["*"]
+
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses", "ingressclasses"]
+    verbs: ["*"]
+
+  - apiGroups: ["policy"]
+    resources: ["poddisruptionbudgets"]
+    verbs: ["*"]
+
+  - apiGroups: ["autoscaling"]
+    resources: ["horizontalpodautoscalers"]
+    verbs: ["*"]
+
+  - apiGroups: ["secrets-store.csi.x-k8s.io"]
+    resources: ["secretproviderclasses"]
+    verbs: ["*"]
+
+  - apiGroups: ["policy.openservicemesh.io"]
+    resources: ["ingressbackends"]
+    verbs: ["*"]
+
+  - apiGroups: ["config.openservicemesh.io"]
+    resources: ["meshconfigs"]
+    verbs: ["*"]


### PR DESCRIPTION
Adds a k8s RBAC role that allows the minimal access required by the operator. Also configures the e2e tests to use it so we can be sure it doesn't break in the future.