### PR TITLE
Configure vscode to honor e2e build tags

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+	"go.buildTags": "e2e"
+}


### PR DESCRIPTION
The e2e package has a build tag that prevents any e2e test cases from running by default. It turns out this breaks intellisense in vscode unless the tag is added to the workspace configuration.