### PR TITLE
Revert #19/#20

### DIFF
--- a/e2e/e2eutil/e2eutil.go
+++ b/e2e/e2eutil/e2eutil.go
@@ -70,6 +70,11 @@ func (c *Case) Retry(fn func() error) {
 	}
 }
 
+func (c *Case) Hostname(domain string) string {
+	c.ensureNS()
+	return strings.ToLower(c.ns) + "." + domain
+}
+
 // WithResources creates Kubernetes resources for the test case and waits for them to become ready.
 func (c *Case) WithResources(resources ...client.Object) {
 	c.ensureNS()

--- a/e2e/fixtures/fixtures.go
+++ b/e2e/fixtures/fixtures.go
@@ -91,8 +91,9 @@ func NewService(app, host, keyvaultURI string, port int32) *corev1.Service {
 		},
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{{
-				Name: "http",
-				Port: port,
+				Name:       "http",
+				Port:       1234, // anything - we don't use this one
+				TargetPort: intstr.FromInt(int(port)),
 			}},
 			Selector: map[string]string{"app": app},
 		},

--- a/e2e/fixtures/fixtures.go
+++ b/e2e/fixtures/fixtures.go
@@ -91,9 +91,8 @@ func NewService(app, host, keyvaultURI string, port int32) *corev1.Service {
 		},
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{{
-				Name:       "http",
-				Port:       port,
-				TargetPort: intstr.FromInt(8080),
+				Name: "http",
+				Port: port,
 			}},
 			Selector: map[string]string{"app": app},
 		},

--- a/pkg/controller/service/ingress_reconciler.go
+++ b/pkg/controller/service/ingress_reconciler.go
@@ -102,7 +102,7 @@ func (i *IngressReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 							Backend: netv1.IngressBackend{
 								Service: &netv1.IngressServiceBackend{
 									Name: svc.Name,
-									Port: netv1.ServiceBackendPort{Number: svc.Spec.Ports[0].Port},
+									Port: netv1.ServiceBackendPort{Number: svc.Spec.Ports[0].TargetPort.IntVal},
 								},
 							},
 						}},

--- a/pkg/controller/service/ingress_reconciler.go
+++ b/pkg/controller/service/ingress_reconciler.go
@@ -12,7 +12,6 @@ import (
 	netv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -71,13 +70,6 @@ func (i *IngressReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		serviceAccount = sa
 	}
 
-	upstreamPort := netv1.ServiceBackendPort{}
-	if svc.Spec.Ports[0].TargetPort.Type == intstr.Int {
-		upstreamPort.Number = svc.Spec.Ports[0].TargetPort.IntVal
-	} else {
-		upstreamPort.Name = svc.Spec.Ports[0].TargetPort.StrVal
-	}
-
 	pt := netv1.PathTypePrefix
 	ing := &netv1.Ingress{
 		TypeMeta: metav1.TypeMeta{
@@ -110,7 +102,7 @@ func (i *IngressReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 							Backend: netv1.IngressBackend{
 								Service: &netv1.IngressServiceBackend{
 									Name: svc.Name,
-									Port: upstreamPort,
+									Port: netv1.ServiceBackendPort{Number: svc.Spec.Ports[0].Port},
 								},
 							},
 						}},

--- a/pkg/controller/service/ingress_reconciler_test.go
+++ b/pkg/controller/service/ingress_reconciler_test.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -28,7 +29,8 @@ func TestIngressReconcilerIntegration(t *testing.T) {
 	svc.Name = "test-service"
 	svc.Namespace = "test-ns"
 	svc.Spec.Ports = []corev1.ServicePort{{
-		Port: 123,
+		Port:       123,
+		TargetPort: intstr.FromInt(234),
 	}}
 
 	c := fake.NewClientBuilder().WithObjects(svc).Build()
@@ -94,7 +96,7 @@ func TestIngressReconcilerIntegration(t *testing.T) {
 							Backend: netv1.IngressBackend{
 								Service: &netv1.IngressServiceBackend{
 									Name: svc.Name,
-									Port: netv1.ServiceBackendPort{Number: svc.Spec.Ports[0].Port},
+									Port: netv1.ServiceBackendPort{Number: svc.Spec.Ports[0].TargetPort.IntVal},
 								},
 							},
 						}},
@@ -133,7 +135,8 @@ func TestIngressReconcilerIntegrationNoOSM(t *testing.T) {
 		"kubernetes.azure.com/insecure-disable-osm":  "true",
 	}
 	svc.Spec.Ports = []corev1.ServicePort{{
-		Port: 123,
+		Port:       123,
+		TargetPort: intstr.FromInt(234),
 	}}
 
 	c := fake.NewClientBuilder().WithObjects(svc).Build()
@@ -179,7 +182,7 @@ func TestIngressReconcilerIntegrationNoOSM(t *testing.T) {
 							Backend: netv1.IngressBackend{
 								Service: &netv1.IngressServiceBackend{
 									Name: svc.Name,
-									Port: netv1.ServiceBackendPort{Number: svc.Spec.Ports[0].Port},
+									Port: netv1.ServiceBackendPort{Number: svc.Spec.Ports[0].TargetPort.IntVal},
 								},
 							},
 						}},

--- a/pkg/controller/service/ingress_reconciler_test.go
+++ b/pkg/controller/service/ingress_reconciler_test.go
@@ -15,7 +15,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -29,8 +28,7 @@ func TestIngressReconcilerIntegration(t *testing.T) {
 	svc.Name = "test-service"
 	svc.Namespace = "test-ns"
 	svc.Spec.Ports = []corev1.ServicePort{{
-		Port:       123,
-		TargetPort: intstr.FromInt(234),
+		Port: 123,
 	}}
 
 	c := fake.NewClientBuilder().WithObjects(svc).Build()
@@ -96,7 +94,7 @@ func TestIngressReconcilerIntegration(t *testing.T) {
 							Backend: netv1.IngressBackend{
 								Service: &netv1.IngressServiceBackend{
 									Name: svc.Name,
-									Port: netv1.ServiceBackendPort{Number: svc.Spec.Ports[0].TargetPort.IntVal},
+									Port: netv1.ServiceBackendPort{Number: svc.Spec.Ports[0].Port},
 								},
 							},
 						}},
@@ -135,8 +133,7 @@ func TestIngressReconcilerIntegrationNoOSM(t *testing.T) {
 		"kubernetes.azure.com/insecure-disable-osm":  "true",
 	}
 	svc.Spec.Ports = []corev1.ServicePort{{
-		Port:       123,
-		TargetPort: intstr.FromInt(234),
+		Port: 123,
 	}}
 
 	c := fake.NewClientBuilder().WithObjects(svc).Build()
@@ -182,7 +179,7 @@ func TestIngressReconcilerIntegrationNoOSM(t *testing.T) {
 							Backend: netv1.IngressBackend{
 								Service: &netv1.IngressServiceBackend{
 									Name: svc.Name,
-									Port: netv1.ServiceBackendPort{Number: svc.Spec.Ports[0].TargetPort.IntVal},
+									Port: netv1.ServiceBackendPort{Number: svc.Spec.Ports[0].Port},
 								},
 							},
 						}},
@@ -198,92 +195,6 @@ func TestIngressReconcilerIntegrationNoOSM(t *testing.T) {
 	ing := &netv1.Ingress{}
 	ing.Name = svc.Name
 	ing.Namespace = svc.Namespace
-	require.NoError(t, c.Get(ctx, client.ObjectKeyFromObject(ing), ing))
-	assert.Equal(t, expected, ing)
-}
-
-func TestIngressReconcilerStringTargetPort(t *testing.T) {
-	svc := &corev1.Service{}
-	svc.UID = "test-svc-uid"
-	svc.Name = "test-service"
-	svc.Namespace = "test-ns"
-	svc.Spec.Ports = []corev1.ServicePort{{
-		Port:       123,
-		TargetPort: intstr.FromString("test port"),
-	}}
-
-	c := fake.NewClientBuilder().WithObjects(svc).Build()
-	p := &IngressReconciler{client: c}
-
-	ctx := context.Background()
-	ctx = logr.NewContext(ctx, logr.Discard())
-
-	ing := &netv1.Ingress{}
-	ing.Name = svc.Name
-	ing.Namespace = svc.Namespace
-	assert.True(t, errors.IsNotFound(c.Get(ctx, client.ObjectKeyFromObject(ing), ing)))
-
-	// Add required annotations and prove the expected ingress is created
-	svc.Annotations = map[string]string{
-		"kubernetes.azure.com/ingress-host":          "test-host",
-		"kubernetes.azure.com/tls-cert-keyvault-uri": "test-cert-uri",
-	}
-	require.NoError(t, c.Update(ctx, svc))
-	req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: svc.Namespace, Name: svc.Name}}
-	_, err := p.Reconcile(ctx, req)
-	require.NoError(t, err)
-
-	pt := netv1.PathTypePrefix
-	expected := &netv1.Ingress{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Ingress",
-			APIVersion: "networking.k8s.io/v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:            svc.Name,
-			Namespace:       svc.Namespace,
-			ResourceVersion: "1",
-			OwnerReferences: []metav1.OwnerReference{{
-				APIVersion: "v1",
-				Controller: util.BoolPtr(true),
-				Kind:       "Service",
-				Name:       svc.Name,
-				UID:        svc.UID,
-			}},
-			Annotations: map[string]string{
-				"kubernetes.azure.com/tls-cert-keyvault-uri":        "test-cert-uri",
-				"kubernetes.azure.com/use-osm-mtls":                 "true",
-				"nginx.ingress.kubernetes.io/backend-protocol":      "HTTPS",
-				"nginx.ingress.kubernetes.io/configuration-snippet": "\nproxy_ssl_name \"default.test-ns.cluster.local\";",
-				"nginx.ingress.kubernetes.io/proxy-ssl-secret":      "kube-system/osm-ingress-client-cert",
-				"nginx.ingress.kubernetes.io/proxy-ssl-verify":      "on",
-			},
-		},
-		Spec: netv1.IngressSpec{
-			IngressClassName: util.StringPtr("webapprouting.kubernetes.azure.com"),
-			Rules: []netv1.IngressRule{{
-				Host: "test-host",
-				IngressRuleValue: netv1.IngressRuleValue{
-					HTTP: &netv1.HTTPIngressRuleValue{
-						Paths: []netv1.HTTPIngressPath{{
-							Path:     "/",
-							PathType: &pt,
-							Backend: netv1.IngressBackend{
-								Service: &netv1.IngressServiceBackend{
-									Name: svc.Name,
-									Port: netv1.ServiceBackendPort{Name: svc.Spec.Ports[0].TargetPort.StrVal},
-								},
-							},
-						}},
-					},
-				},
-			}},
-			TLS: []netv1.IngressTLS{{
-				Hosts:      []string{"test-host"},
-				SecretName: "keyvault-test-service",
-			}},
-		},
-	}
 	require.NoError(t, c.Get(ctx, client.ObjectKeyFromObject(ing), ing))
 	assert.Equal(t, expected, ing)
 }


### PR DESCRIPTION
It turns out OSM doesn't support named ports, so #19 and #20 are irrelevant.

In the process of discovering this, I realized that e2e always passes because every test case uses the same ingress hostname, so all test requests target the first test case's server, which works.