### PR TITLE
Enable leader election

### DIFF
--- a/rbac.yaml
+++ b/rbac.yaml
@@ -45,3 +45,7 @@ rules:
   - apiGroups: ["config.openservicemesh.io"]
     resources: ["meshconfigs"]
     verbs: ["*"]
+
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["*"]


### PR DESCRIPTION
Allow multiple replicas to run concurrently. Also adds a call to `AddHealthzCheck` since it turns out that is required to register the health probe handler routes.