### PR TITLE
Add protections around nginx snippet configurations

### DIFF
--- a/pkg/manifests/fixtures/full.json
+++ b/pkg/manifests/fixtures/full.json
@@ -220,6 +220,7 @@
                   "/nginx-ingress-controller",
                   "--ingress-class=webapprouting.kubernetes.azure.com",
                   "--publish-service=$(POD_NAMESPACE)/nginx",
+                  "--configmap=$(POD_NAMESPACE)/nginx",
                   "--http-port=8080",
                   "--https-port=8443"
                 ],
@@ -338,6 +339,21 @@
         "revisionHistoryLimit": 2
       },
       "status": {}
+    },
+    {
+      "kind": "ConfigMap",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "nginx",
+        "namespace": "test-namespace",
+        "creationTimestamp": null,
+        "labels": {
+          "app.kubernetes.io/managed-by": "aks-app-routing-operator"
+        }
+      },
+      "data": {
+        "annotation-value-word-blocklist": "load_module,lua_package,_by_lua,location,root,proxy_pass,serviceaccount,{,},'"
+      }
     },
     {
       "kind": "PodDisruptionBudget",

--- a/pkg/manifests/fixtures/optional-features-disabled.json
+++ b/pkg/manifests/fixtures/optional-features-disabled.json
@@ -216,6 +216,7 @@
                   "/nginx-ingress-controller",
                   "--ingress-class=webapprouting.kubernetes.azure.com",
                   "--publish-service=$(POD_NAMESPACE)/nginx",
+                  "--configmap=$(POD_NAMESPACE)/nginx",
                   "--http-port=8080",
                   "--https-port=8443"
                 ],
@@ -334,6 +335,21 @@
         "revisionHistoryLimit": 2
       },
       "status": {}
+    },
+    {
+      "kind": "ConfigMap",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "nginx",
+        "namespace": "test-namespace",
+        "creationTimestamp": null,
+        "labels": {
+          "app.kubernetes.io/managed-by": "aks-app-routing-operator"
+        }
+      },
+      "data": {
+        "annotation-value-word-blocklist": "load_module,lua_package,_by_lua,location,root,proxy_pass,serviceaccount,{,},'"
+      }
     },
     {
       "kind": "PodDisruptionBudget",

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -284,6 +284,7 @@ func newIngressControllerConfigmap(conf *config.Config) *corev1.ConfigMap {
 		Data: map[string]string{
 			// Can't use 'allow-snippet-annotations=false' to reduce injection risk, since we require snippet functionality for OSM routing.
 			// But we can still protect against leaked service account tokens.
+			// See: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#annotation-value-word-blocklist
 			"annotation-value-word-blocklist": "load_module,lua_package,_by_lua,location,root,proxy_pass,serviceaccount,{,},'",
 		},
 	}


### PR DESCRIPTION
Prevents users from acquiring service account tokens by injecting malicious nginx configuration through ingress annotations while still preserving the ability to use snippets required by OSM.