### PR TITLE
Enable ingress controller resource cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,4 +15,4 @@ push:
 	az acr login -n `cat devenv/state/registry.txt`
 	docker build -t `cat devenv/state/operator-image-tag.txt` .
 	docker push `cat devenv/state/operator-image-tag.txt`
-	kubectl set image --kubeconfig devenv/state/kubeconfig deployments/app-routing-operator operator=`cat devenv/state/operator-image-tag.txt`
+	kubectl set image -n kube-system --kubeconfig devenv/state/kubeconfig deployments/app-routing-operator operator=`cat devenv/state/operator-image-tag.txt`

--- a/devenv/main.tf
+++ b/devenv/main.tf
@@ -195,7 +195,8 @@ resource "kubernetes_deployment_v1" "operator" {
   }
 
   metadata {
-    name = "app-routing-operator"
+    name      = "app-routing-operator"
+    namespace = "kube-system"
   }
 
   spec {
@@ -247,7 +248,7 @@ resource "kubernetes_cluster_role_binding_v1" "defaultadmin" {
   subject {
     kind      = "ServiceAccount"
     name      = "default"
-    namespace = "default"
+    namespace = "kube-system"
   }
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -11,7 +11,7 @@ import (
 var Flags = &Config{}
 
 func init() {
-	flag.StringVar(&Flags.NS, "namespace", "app-routing-system", "namespace for managed resources")
+	flag.StringVar(&Flags.NS, "namespace", "app-routing-system", "namespace for managed resources (deprecated: omit flag to use kube-system instead)")
 	flag.StringVar(&Flags.Registry, "registry", "mcr.microsoft.com", "container image registry to use for managed components")
 	flag.StringVar(&Flags.MSIClientID, "msi", "", "client ID of the MSI to use when accessing Azure resources")
 	flag.StringVar(&Flags.TenantID, "tenant-id", "", "AAD tenant ID to use when accessing Azure resources")
@@ -28,6 +28,7 @@ func init() {
 	flag.StringVar(&Flags.ServiceAccountTokenPath, "service-account-token-path", "", "optionally override the default token path")
 	flag.StringVar(&Flags.MetricsAddr, "metrics-addr", "0.0.0.0:8081", "address to serve Prometheus metrics on")
 	flag.StringVar(&Flags.ProbeAddr, "probe-addr", "0.0.0.0:8080", "address to serve readiness/liveness probes on")
+	flag.StringVar(&Flags.OperatorDeploy, "operator-deploy", "app-routing-operator", "name of the operator's k8s deployment")
 }
 
 type Config struct {
@@ -41,6 +42,7 @@ type Config struct {
 	ConcurrencyWatchdogThres                          float64
 	ConcurrencyWatchdogVotes                          int
 	DisableOSM                                        bool
+	OperatorDeploy                                    string
 }
 
 func (c *Config) Validate() error {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -28,7 +28,7 @@ func init() {
 	flag.StringVar(&Flags.ServiceAccountTokenPath, "service-account-token-path", "", "optionally override the default token path")
 	flag.StringVar(&Flags.MetricsAddr, "metrics-addr", "0.0.0.0:8081", "address to serve Prometheus metrics on")
 	flag.StringVar(&Flags.ProbeAddr, "probe-addr", "0.0.0.0:8080", "address to serve readiness/liveness probes on")
-	flag.StringVar(&Flags.OperatorDeploy, "operator-deploy", "app-routing-operator", "name of the operator's k8s deployment")
+	flag.StringVar(&Flags.OperatorDeployment, "operator-deployment", "app-routing-operator", "name of the operator's k8s deployment")
 }
 
 type Config struct {
@@ -42,7 +42,7 @@ type Config struct {
 	ConcurrencyWatchdogThres                          float64
 	ConcurrencyWatchdogVotes                          int
 	DisableOSM                                        bool
-	OperatorDeploy                                    string
+	OperatorDeployment                                string
 }
 
 func (c *Config) Validate() error {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -114,7 +114,7 @@ func checkNamespace(kcs kubernetes.Interface, conf *config.Config) error {
 }
 
 func getSelfDeploy(kcs kubernetes.Interface, conf *config.Config) (*appsv1.Deployment, error) {
-	deploy, err := kcs.AppsV1().Deployments(conf.NS).Get(context.Background(), conf.OperatorDeploy, metav1.GetOptions{})
+	deploy, err := kcs.AppsV1().Deployments(conf.NS).Get(context.Background(), conf.OperatorDeployment, metav1.GetOptions{})
 	if errors.IsNotFound(err) {
 		// It's okay if we don't find the deployment - just skip setting ownership references
 		err = nil

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/Azure/aks-app-routing-operator/pkg/config"
+)
+
+func TestCheckNamespace(t *testing.T) {
+	t.Run("namespace exists", func(t *testing.T) {
+		kcs := fake.NewSimpleClientset()
+		conf := &config.Config{NS: "app-routing-system"}
+
+		ns := &corev1.Namespace{}
+		ns.Name = conf.NS
+		kcs.CoreV1().Namespaces().Create(context.Background(), ns, metav1.CreateOptions{})
+
+		require.NoError(t, checkNamespace(kcs, conf))
+		assert.Equal(t, "app-routing-system", conf.NS)
+	})
+
+	t.Run("namespace deleting", func(t *testing.T) {
+		kcs := fake.NewSimpleClientset()
+		conf := &config.Config{NS: "app-routing-system"}
+
+		ns := &corev1.Namespace{}
+		ns.Name = conf.NS
+		ns.DeletionTimestamp = &metav1.Time{}
+		kcs.CoreV1().Namespaces().Create(context.Background(), ns, metav1.CreateOptions{})
+
+		require.NoError(t, checkNamespace(kcs, conf))
+		assert.Equal(t, "kube-system", conf.NS)
+	})
+
+	t.Run("namespace missing", func(t *testing.T) {
+		kcs := fake.NewSimpleClientset()
+		conf := &config.Config{NS: "app-routing-system"}
+
+		require.NoError(t, checkNamespace(kcs, conf))
+		assert.Equal(t, "kube-system", conf.NS)
+	})
+
+	t.Run("kube-system", func(t *testing.T) {
+		kcs := fake.NewSimpleClientset()
+
+		conf := &config.Config{NS: "kube-system"}
+		require.NoError(t, checkNamespace(kcs, conf))
+		assert.Equal(t, "kube-system", conf.NS)
+	})
+}

--- a/pkg/manifests/fixtures/kube-system.json
+++ b/pkg/manifests/fixtures/kube-system.json
@@ -1,39 +1,10 @@
 [
     {
-      "kind": "Namespace",
-      "apiVersion": "v1",
-      "metadata": {
-        "name": "test-namespace",
-        "creationTimestamp": null,
-        "labels": {
-          "app.kubernetes.io/managed-by": "aks-app-routing-operator"
-        },
-        "ownerReferences": [
-          {
-            "apiVersion": "apps/v1",
-            "kind": "Deployment",
-            "name": "test-operator-deploy",
-            "uid": "test-operator-deploy-uid"
-          }
-        ]
-      },
-      "spec": {},
-      "status": {}
-    },
-    {
       "kind": "IngressClass",
       "apiVersion": "networking.k8s.io/v1",
       "metadata": {
         "name": "webapprouting.kubernetes.azure.com",
-        "creationTimestamp": null,
-        "ownerReferences": [
-          {
-            "apiVersion": "apps/v1",
-            "kind": "Deployment",
-            "name": "test-operator-deploy",
-            "uid": "test-operator-deploy-uid"
-          }
-        ]
+        "creationTimestamp": null
       },
       "spec": {
         "controller": "k8s.io/ingress-nginx"
@@ -44,19 +15,11 @@
       "apiVersion": "v1",
       "metadata": {
         "name": "nginx",
-        "namespace": "test-namespace",
+        "namespace": "kube-system",
         "creationTimestamp": null,
         "labels": {
           "app.kubernetes.io/managed-by": "aks-app-routing-operator"
-        },
-        "ownerReferences": [
-          {
-            "apiVersion": "apps/v1",
-            "kind": "Deployment",
-            "name": "test-operator-deploy",
-            "uid": "test-operator-deploy-uid"
-          }
-        ]
+        }
       }
     },
     {
@@ -67,15 +30,7 @@
         "creationTimestamp": null,
         "labels": {
           "app.kubernetes.io/managed-by": "aks-app-routing-operator"
-        },
-        "ownerReferences": [
-          {
-            "apiVersion": "apps/v1",
-            "kind": "Deployment",
-            "name": "test-operator-deploy",
-            "uid": "test-operator-deploy-uid"
-          }
-        ]
+        }
       },
       "rules": [
         {
@@ -166,21 +121,13 @@
         "creationTimestamp": null,
         "labels": {
           "app.kubernetes.io/managed-by": "aks-app-routing-operator"
-        },
-        "ownerReferences": [
-          {
-            "apiVersion": "apps/v1",
-            "kind": "Deployment",
-            "name": "test-operator-deploy",
-            "uid": "test-operator-deploy-uid"
-          }
-        ]
+        }
       },
       "subjects": [
         {
           "kind": "ServiceAccount",
           "name": "nginx",
-          "namespace": "test-namespace"
+          "namespace": "kube-system"
         }
       ],
       "roleRef": {
@@ -194,19 +141,11 @@
       "apiVersion": "v1",
       "metadata": {
         "name": "nginx",
-        "namespace": "test-namespace",
+        "namespace": "kube-system",
         "creationTimestamp": null,
         "labels": {
           "app.kubernetes.io/managed-by": "aks-app-routing-operator"
-        },
-        "ownerReferences": [
-          {
-            "apiVersion": "apps/v1",
-            "kind": "Deployment",
-            "name": "test-operator-deploy",
-            "uid": "test-operator-deploy-uid"
-          }
-        ]
+        }
       },
       "spec": {
         "ports": [
@@ -236,19 +175,11 @@
       "apiVersion": "apps/v1",
       "metadata": {
         "name": "nginx",
-        "namespace": "test-namespace",
+        "namespace": "kube-system",
         "creationTimestamp": null,
         "labels": {
           "app.kubernetes.io/managed-by": "aks-app-routing-operator"
-        },
-        "ownerReferences": [
-          {
-            "apiVersion": "apps/v1",
-            "kind": "Deployment",
-            "name": "test-operator-deploy",
-            "uid": "test-operator-deploy-uid"
-          }
-        ]
+        }
       },
       "spec": {
         "selector": {
@@ -400,19 +331,11 @@
       "apiVersion": "v1",
       "metadata": {
         "name": "nginx",
-        "namespace": "test-namespace",
+        "namespace": "kube-system",
         "creationTimestamp": null,
         "labels": {
           "app.kubernetes.io/managed-by": "aks-app-routing-operator"
-        },
-        "ownerReferences": [
-          {
-            "apiVersion": "apps/v1",
-            "kind": "Deployment",
-            "name": "test-operator-deploy",
-            "uid": "test-operator-deploy-uid"
-          }
-        ]
+        }
       },
       "data": {
         "annotation-value-word-blocklist": "load_module,lua_package,_by_lua,location,root,proxy_pass,serviceaccount,{,},'"
@@ -423,19 +346,11 @@
       "apiVersion": "policy/v1",
       "metadata": {
         "name": "nginx",
-        "namespace": "test-namespace",
+        "namespace": "kube-system",
         "creationTimestamp": null,
         "labels": {
           "app.kubernetes.io/managed-by": "aks-app-routing-operator"
-        },
-        "ownerReferences": [
-          {
-            "apiVersion": "apps/v1",
-            "kind": "Deployment",
-            "name": "test-operator-deploy",
-            "uid": "test-operator-deploy-uid"
-          }
-        ]
+        }
       },
       "spec": {
         "selector": {
@@ -457,19 +372,11 @@
       "apiVersion": "autoscaling/v1",
       "metadata": {
         "name": "nginx",
-        "namespace": "test-namespace",
+        "namespace": "kube-system",
         "creationTimestamp": null,
         "labels": {
           "app.kubernetes.io/managed-by": "aks-app-routing-operator"
-        },
-        "ownerReferences": [
-          {
-            "apiVersion": "apps/v1",
-            "kind": "Deployment",
-            "name": "test-operator-deploy",
-            "uid": "test-operator-deploy-uid"
-          }
-        ]
+        }
       },
       "spec": {
         "scaleTargetRef": {
@@ -491,19 +398,11 @@
       "apiVersion": "v1",
       "metadata": {
         "name": "external-dns",
-        "namespace": "test-namespace",
+        "namespace": "kube-system",
         "creationTimestamp": null,
         "labels": {
           "app.kubernetes.io/managed-by": "aks-app-routing-operator"
-        },
-        "ownerReferences": [
-          {
-            "apiVersion": "apps/v1",
-            "kind": "Deployment",
-            "name": "test-operator-deploy",
-            "uid": "test-operator-deploy-uid"
-          }
-        ]
+        }
       },
       "data": {
         "azure.json": "{\"cloud\":\"test-cloud\",\"location\":\"test-location\",\"resourceGroup\":\"test-dns-zone-rg\",\"subscriptionId\":\"test-dns-zone-sub\",\"tenantId\":\"test-tenant-id\",\"useManagedIdentityExtension\":true,\"userAssignedIdentityID\":\"test-msi-client-id\"}"
@@ -514,19 +413,11 @@
       "apiVersion": "apps/v1",
       "metadata": {
         "name": "external-dns",
-        "namespace": "test-namespace",
+        "namespace": "kube-system",
         "creationTimestamp": null,
         "labels": {
           "app.kubernetes.io/managed-by": "aks-app-routing-operator"
-        },
-        "ownerReferences": [
-          {
-            "apiVersion": "apps/v1",
-            "kind": "Deployment",
-            "name": "test-operator-deploy",
-            "uid": "test-operator-deploy-uid"
-          }
-        ]
+        }
       },
       "spec": {
         "replicas": 1,

--- a/pkg/manifests/fixtures/no-ownership.json
+++ b/pkg/manifests/fixtures/no-ownership.json
@@ -7,15 +7,7 @@
         "creationTimestamp": null,
         "labels": {
           "app.kubernetes.io/managed-by": "aks-app-routing-operator"
-        },
-        "ownerReferences": [
-          {
-            "apiVersion": "apps/v1",
-            "kind": "Deployment",
-            "name": "test-operator-deploy",
-            "uid": "test-operator-deploy-uid"
-          }
-        ]
+        }
       },
       "spec": {},
       "status": {}
@@ -25,15 +17,7 @@
       "apiVersion": "networking.k8s.io/v1",
       "metadata": {
         "name": "webapprouting.kubernetes.azure.com",
-        "creationTimestamp": null,
-        "ownerReferences": [
-          {
-            "apiVersion": "apps/v1",
-            "kind": "Deployment",
-            "name": "test-operator-deploy",
-            "uid": "test-operator-deploy-uid"
-          }
-        ]
+        "creationTimestamp": null
       },
       "spec": {
         "controller": "k8s.io/ingress-nginx"
@@ -48,15 +32,7 @@
         "creationTimestamp": null,
         "labels": {
           "app.kubernetes.io/managed-by": "aks-app-routing-operator"
-        },
-        "ownerReferences": [
-          {
-            "apiVersion": "apps/v1",
-            "kind": "Deployment",
-            "name": "test-operator-deploy",
-            "uid": "test-operator-deploy-uid"
-          }
-        ]
+        }
       }
     },
     {
@@ -67,15 +43,7 @@
         "creationTimestamp": null,
         "labels": {
           "app.kubernetes.io/managed-by": "aks-app-routing-operator"
-        },
-        "ownerReferences": [
-          {
-            "apiVersion": "apps/v1",
-            "kind": "Deployment",
-            "name": "test-operator-deploy",
-            "uid": "test-operator-deploy-uid"
-          }
-        ]
+        }
       },
       "rules": [
         {
@@ -166,15 +134,7 @@
         "creationTimestamp": null,
         "labels": {
           "app.kubernetes.io/managed-by": "aks-app-routing-operator"
-        },
-        "ownerReferences": [
-          {
-            "apiVersion": "apps/v1",
-            "kind": "Deployment",
-            "name": "test-operator-deploy",
-            "uid": "test-operator-deploy-uid"
-          }
-        ]
+        }
       },
       "subjects": [
         {
@@ -198,15 +158,7 @@
         "creationTimestamp": null,
         "labels": {
           "app.kubernetes.io/managed-by": "aks-app-routing-operator"
-        },
-        "ownerReferences": [
-          {
-            "apiVersion": "apps/v1",
-            "kind": "Deployment",
-            "name": "test-operator-deploy",
-            "uid": "test-operator-deploy-uid"
-          }
-        ]
+        }
       },
       "spec": {
         "ports": [
@@ -240,15 +192,7 @@
         "creationTimestamp": null,
         "labels": {
           "app.kubernetes.io/managed-by": "aks-app-routing-operator"
-        },
-        "ownerReferences": [
-          {
-            "apiVersion": "apps/v1",
-            "kind": "Deployment",
-            "name": "test-operator-deploy",
-            "uid": "test-operator-deploy-uid"
-          }
-        ]
+        }
       },
       "spec": {
         "selector": {
@@ -404,15 +348,7 @@
         "creationTimestamp": null,
         "labels": {
           "app.kubernetes.io/managed-by": "aks-app-routing-operator"
-        },
-        "ownerReferences": [
-          {
-            "apiVersion": "apps/v1",
-            "kind": "Deployment",
-            "name": "test-operator-deploy",
-            "uid": "test-operator-deploy-uid"
-          }
-        ]
+        }
       },
       "data": {
         "annotation-value-word-blocklist": "load_module,lua_package,_by_lua,location,root,proxy_pass,serviceaccount,{,},'"
@@ -427,15 +363,7 @@
         "creationTimestamp": null,
         "labels": {
           "app.kubernetes.io/managed-by": "aks-app-routing-operator"
-        },
-        "ownerReferences": [
-          {
-            "apiVersion": "apps/v1",
-            "kind": "Deployment",
-            "name": "test-operator-deploy",
-            "uid": "test-operator-deploy-uid"
-          }
-        ]
+        }
       },
       "spec": {
         "selector": {
@@ -461,15 +389,7 @@
         "creationTimestamp": null,
         "labels": {
           "app.kubernetes.io/managed-by": "aks-app-routing-operator"
-        },
-        "ownerReferences": [
-          {
-            "apiVersion": "apps/v1",
-            "kind": "Deployment",
-            "name": "test-operator-deploy",
-            "uid": "test-operator-deploy-uid"
-          }
-        ]
+        }
       },
       "spec": {
         "scaleTargetRef": {
@@ -495,15 +415,7 @@
         "creationTimestamp": null,
         "labels": {
           "app.kubernetes.io/managed-by": "aks-app-routing-operator"
-        },
-        "ownerReferences": [
-          {
-            "apiVersion": "apps/v1",
-            "kind": "Deployment",
-            "name": "test-operator-deploy",
-            "uid": "test-operator-deploy-uid"
-          }
-        ]
+        }
       },
       "data": {
         "azure.json": "{\"cloud\":\"test-cloud\",\"location\":\"test-location\",\"resourceGroup\":\"test-dns-zone-rg\",\"subscriptionId\":\"test-dns-zone-sub\",\"tenantId\":\"test-tenant-id\",\"useManagedIdentityExtension\":true,\"userAssignedIdentityID\":\"test-msi-client-id\"}"
@@ -518,15 +430,7 @@
         "creationTimestamp": null,
         "labels": {
           "app.kubernetes.io/managed-by": "aks-app-routing-operator"
-        },
-        "ownerReferences": [
-          {
-            "apiVersion": "apps/v1",
-            "kind": "Deployment",
-            "name": "test-operator-deploy",
-            "uid": "test-operator-deploy-uid"
-          }
-        ]
+        }
       },
       "spec": {
         "replicas": 1,

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -10,19 +10,57 @@ import (
 	"path"
 	"testing"
 
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/Azure/aks-app-routing-operator/pkg/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 var integrationTestCases = []struct {
-	Name string
-	Conf *config.Config
+	Name   string
+	Conf   *config.Config
+	Deploy *appsv1.Deployment
 }{
 	{
 		Name: "full",
 		Conf: &config.Config{
 			NS:            "test-namespace",
+			Registry:      "test-registry",
+			MSIClientID:   "test-msi-client-id",
+			TenantID:      "test-tenant-id",
+			Cloud:         "test-cloud",
+			Location:      "test-location",
+			DNSZoneRG:     "test-dns-zone-rg",
+			DNSZoneSub:    "test-dns-zone-sub",
+			DNSZoneDomain: "test-dns-zone-domain",
+		},
+		Deploy: &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-operator-deploy",
+				UID:  "test-operator-deploy-uid",
+			},
+		},
+	},
+	{
+		Name: "no-ownership",
+		Conf: &config.Config{
+			NS:            "test-namespace",
+			Registry:      "test-registry",
+			MSIClientID:   "test-msi-client-id",
+			TenantID:      "test-tenant-id",
+			Cloud:         "test-cloud",
+			Location:      "test-location",
+			DNSZoneRG:     "test-dns-zone-rg",
+			DNSZoneSub:    "test-dns-zone-sub",
+			DNSZoneDomain: "test-dns-zone-domain",
+		},
+	},
+	{
+		Name: "kube-system",
+		Conf: &config.Config{
+			NS:            "kube-system",
 			Registry:      "test-registry",
 			MSIClientID:   "test-msi-client-id",
 			TenantID:      "test-tenant-id",
@@ -50,7 +88,7 @@ var integrationTestCases = []struct {
 
 func TestIngressControllerResources(t *testing.T) {
 	for _, tc := range integrationTestCases {
-		objs := IngressControllerResources(tc.Conf)
+		objs := IngressControllerResources(tc.Conf, tc.Deploy)
 
 		actual, err := json.MarshalIndent(&objs, "  ", "  ")
 		require.NoError(t, err)


### PR DESCRIPTION
The ingress controller components will now run in kube-system instead of app-routing-system, along with the operator. The managed resources are now owned by the operator so that they will be automatically cleaned up when the operator deployment is deleted.

Back compatibility is maintained by checking if the app-routing-system namespace exists and continuing to use it if so.