### PR TITLE
remove kube-system migration code

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -11,7 +11,7 @@ import (
 var Flags = &Config{}
 
 func init() {
-	flag.StringVar(&Flags.NS, "namespace", "app-routing-system", "namespace for managed resources (deprecated: omit flag to use kube-system instead)")
+	flag.StringVar(&Flags.NS, "namespace", "app-routing-system", "namespace for managed resources")
 	flag.StringVar(&Flags.Registry, "registry", "mcr.microsoft.com", "container image registry to use for managed components")
 	flag.StringVar(&Flags.MSIClientID, "msi", "", "client ID of the MSI to use when accessing Azure resources")
 	flag.StringVar(&Flags.TenantID, "tenant-id", "", "AAD tenant ID to use when accessing Azure resources")

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -18,49 +18,6 @@ import (
 	"github.com/Azure/aks-app-routing-operator/pkg/config"
 )
 
-func TestCheckNamespace(t *testing.T) {
-	t.Run("namespace exists", func(t *testing.T) {
-		kcs := fake.NewSimpleClientset()
-		conf := &config.Config{NS: "app-routing-system"}
-
-		ns := &corev1.Namespace{}
-		ns.Name = conf.NS
-		kcs.CoreV1().Namespaces().Create(context.Background(), ns, metav1.CreateOptions{})
-
-		require.NoError(t, checkNamespace(kcs, conf))
-		assert.Equal(t, "app-routing-system", conf.NS)
-	})
-
-	t.Run("namespace deleting", func(t *testing.T) {
-		kcs := fake.NewSimpleClientset()
-		conf := &config.Config{NS: "app-routing-system"}
-
-		ns := &corev1.Namespace{}
-		ns.Name = conf.NS
-		ns.DeletionTimestamp = &metav1.Time{}
-		kcs.CoreV1().Namespaces().Create(context.Background(), ns, metav1.CreateOptions{})
-
-		require.NoError(t, checkNamespace(kcs, conf))
-		assert.Equal(t, "kube-system", conf.NS)
-	})
-
-	t.Run("namespace missing", func(t *testing.T) {
-		kcs := fake.NewSimpleClientset()
-		conf := &config.Config{NS: "app-routing-system"}
-
-		require.NoError(t, checkNamespace(kcs, conf))
-		assert.Equal(t, "kube-system", conf.NS)
-	})
-
-	t.Run("kube-system", func(t *testing.T) {
-		kcs := fake.NewSimpleClientset()
-
-		conf := &config.Config{NS: "kube-system"}
-		require.NoError(t, checkNamespace(kcs, conf))
-		assert.Equal(t, "kube-system", conf.NS)
-	})
-}
-
 func TestGetSelfDeploy(t *testing.T) {
 	t.Run("deploy exists", func(t *testing.T) {
 		kcs := fake.NewSimpleClientset()

--- a/pkg/manifests/external_dns.go
+++ b/pkg/manifests/external_dns.go
@@ -30,15 +30,16 @@ type ExternalDnsConfig struct {
 
 // ExternalDnsResources returns Kubernetes objects required for external dns
 func ExternalDnsResources(conf *config.Config, self *appsv1.Deployment, externalDnsConfig *ExternalDnsConfig) []client.Object {
-	objs := []client.Object{
-		newExternalDNSServiceAccount(conf, externalDnsConfig),
-		newExternalDNSClusterRole(conf, externalDnsConfig),
-		newExternalDNSClusterRoleBinding(conf, externalDnsConfig),
-	}
+	objs := []client.Object{}
 
+	// Can safely assume the namespace exists if using kube-system
 	if conf.NS != "kube-system" {
 		objs = append(objs, namespace(conf))
 	}
+
+	objs = append(objs, newExternalDNSServiceAccount(conf, externalDnsConfig))
+	objs = append(objs, newExternalDNSClusterRole(conf, externalDnsConfig))
+	objs = append(objs, newExternalDNSClusterRoleBinding(conf, externalDnsConfig))
 
 	dnsCm, dnsCmHash := newExternalDNSConfigMap(conf, externalDnsConfig)
 	objs = append(objs, dnsCm)

--- a/pkg/manifests/fixtures/external_dns/full.json
+++ b/pkg/manifests/fixtures/external_dns/full.json
@@ -1,5 +1,26 @@
 [
     {
+      "kind": "Namespace",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "test-namespace",
+        "creationTimestamp": null,
+        "labels": {
+          "app.kubernetes.io/managed-by": "aks-app-routing-operator"
+        },
+        "ownerReferences": [
+          {
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "name": "test-operator-deploy",
+            "uid": "test-operator-deploy-uid"
+          }
+        ]
+      },
+      "spec": {},
+      "status": {}
+    },
+    {
       "kind": "ServiceAccount",
       "apiVersion": "v1",
       "metadata": {
@@ -113,27 +134,6 @@
         "kind": "ClusterRole",
         "name": "external-dns"
       }
-    },
-    {
-      "kind": "Namespace",
-      "apiVersion": "v1",
-      "metadata": {
-        "name": "test-namespace",
-        "creationTimestamp": null,
-        "labels": {
-          "app.kubernetes.io/managed-by": "aks-app-routing-operator"
-        },
-        "ownerReferences": [
-          {
-            "apiVersion": "apps/v1",
-            "kind": "Deployment",
-            "name": "test-operator-deploy",
-            "uid": "test-operator-deploy-uid"
-          }
-        ]
-      },
-      "spec": {},
-      "status": {}
     },
     {
       "kind": "ConfigMap",

--- a/pkg/manifests/fixtures/external_dns/no-ownership.json
+++ b/pkg/manifests/fixtures/external_dns/no-ownership.json
@@ -1,5 +1,18 @@
 [
     {
+      "kind": "Namespace",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "test-namespace",
+        "creationTimestamp": null,
+        "labels": {
+          "app.kubernetes.io/managed-by": "aks-app-routing-operator"
+        }
+      },
+      "spec": {},
+      "status": {}
+    },
+    {
       "kind": "ServiceAccount",
       "apiVersion": "v1",
       "metadata": {
@@ -89,19 +102,6 @@
         "kind": "ClusterRole",
         "name": "external-dns"
       }
-    },
-    {
-      "kind": "Namespace",
-      "apiVersion": "v1",
-      "metadata": {
-        "name": "test-namespace",
-        "creationTimestamp": null,
-        "labels": {
-          "app.kubernetes.io/managed-by": "aks-app-routing-operator"
-        }
-      },
-      "spec": {},
-      "status": {}
     },
     {
       "kind": "ConfigMap",

--- a/pkg/manifests/fixtures/external_dns/private.json
+++ b/pkg/manifests/fixtures/external_dns/private.json
@@ -1,5 +1,26 @@
 [
     {
+      "kind": "Namespace",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "test-namespace",
+        "creationTimestamp": null,
+        "labels": {
+          "app.kubernetes.io/managed-by": "aks-app-routing-operator"
+        },
+        "ownerReferences": [
+          {
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "name": "test-operator-deploy",
+            "uid": "test-operator-deploy-uid"
+          }
+        ]
+      },
+      "spec": {},
+      "status": {}
+    },
+    {
       "kind": "ServiceAccount",
       "apiVersion": "v1",
       "metadata": {
@@ -113,27 +134,6 @@
         "kind": "ClusterRole",
         "name": "private-dns"
       }
-    },
-    {
-      "kind": "Namespace",
-      "apiVersion": "v1",
-      "metadata": {
-        "name": "test-namespace",
-        "creationTimestamp": null,
-        "labels": {
-          "app.kubernetes.io/managed-by": "aks-app-routing-operator"
-        },
-        "ownerReferences": [
-          {
-            "apiVersion": "apps/v1",
-            "kind": "Deployment",
-            "name": "test-operator-deploy",
-            "uid": "test-operator-deploy-uid"
-          }
-        ]
-      },
-      "spec": {},
-      "status": {}
     },
     {
       "kind": "ConfigMap",


### PR DESCRIPTION
# Description

The plan was to originally move from `app-routing-system` namespace to `kube-system`. That's no longer the plan (because customers will need to edit services created by web app routing and `kube-system` means "don't touch").

The code being removed here was never actually released or deployed. We can safetly remove it. Without this change, when we release the operator it will create resources in the `kube-system` namespace which we don't want.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Is it a breaking change which will impact consuming tool(s)?

- [x] Tested e2e locally
- [x] Unit tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
