### PR TITLE
add prometheus annotations to Ingress controllers

### DIFF
--- a/pkg/manifests/fixtures/nginx/full.json
+++ b/pkg/manifests/fixtures/nginx/full.json
@@ -191,6 +191,10 @@
         "labels": {
           "app.kubernetes.io/managed-by": "aks-app-routing-operator"
         },
+        "annotations": {
+          "prometheus.io/port": "10254",
+          "prometheus.io/scrape": "true"
+        },
         "ownerReferences": [
           {
             "apiVersion": "apps/v1",
@@ -211,6 +215,11 @@
             "name": "https",
             "port": 443,
             "targetPort": "https"
+          },
+          {
+            "name": "prometheus",
+            "port": 10254,
+            "targetPort": "prometheus"
           }
         ],
         "selector": {
@@ -255,7 +264,9 @@
               "app": "nginx"
             },
             "annotations": {
-              "openservicemesh.io/sidecar-injection": "enabled"
+              "openservicemesh.io/sidecar-injection": "enabled",
+              "prometheus.io/port": "10254",
+              "prometheus.io/scrape": "true"
             }
           },
           "spec": {
@@ -281,6 +292,10 @@
                   {
                     "name": "https",
                     "containerPort": 8443
+                  },
+                  {
+                    "name": "prometheus",
+                    "containerPort": 10254
                   }
                 ],
                 "env": [

--- a/pkg/manifests/fixtures/nginx/internal.json
+++ b/pkg/manifests/fixtures/nginx/internal.json
@@ -194,6 +194,8 @@
         "annotations": {
           "external-dns.alpha.kubernetes.io/hostname": "loadbalancer.test.hostname.com",
           "external-dns.alpha.kubernetes.io/internal-hostname": "clusterip.test.hostname.com",
+          "prometheus.io/port": "10254",
+          "prometheus.io/scrape": "true",
           "service.beta.kubernetes.io/azure-load-balancer-internal": "true"
         },
         "ownerReferences": [
@@ -216,6 +218,11 @@
             "name": "https",
             "port": 443,
             "targetPort": "https"
+          },
+          {
+            "name": "prometheus",
+            "port": 10254,
+            "targetPort": "prometheus"
           }
         ],
         "selector": {
@@ -260,7 +267,9 @@
               "app": "nginx"
             },
             "annotations": {
-              "openservicemesh.io/sidecar-injection": "enabled"
+              "openservicemesh.io/sidecar-injection": "enabled",
+              "prometheus.io/port": "10254",
+              "prometheus.io/scrape": "true"
             }
           },
           "spec": {
@@ -286,6 +295,10 @@
                   {
                     "name": "https",
                     "containerPort": 8443
+                  },
+                  {
+                    "name": "prometheus",
+                    "containerPort": 10254
                   }
                 ],
                 "env": [

--- a/pkg/manifests/fixtures/nginx/kube-system.json
+++ b/pkg/manifests/fixtures/nginx/kube-system.json
@@ -145,6 +145,10 @@
         "creationTimestamp": null,
         "labels": {
           "app.kubernetes.io/managed-by": "aks-app-routing-operator"
+        },
+        "annotations": {
+          "prometheus.io/port": "10254",
+          "prometheus.io/scrape": "true"
         }
       },
       "spec": {
@@ -158,6 +162,11 @@
             "name": "https",
             "port": 443,
             "targetPort": "https"
+          },
+          {
+            "name": "prometheus",
+            "port": 10254,
+            "targetPort": "prometheus"
           }
         ],
         "selector": {
@@ -194,7 +203,9 @@
               "app": "nginx"
             },
             "annotations": {
-              "openservicemesh.io/sidecar-injection": "enabled"
+              "openservicemesh.io/sidecar-injection": "enabled",
+              "prometheus.io/port": "10254",
+              "prometheus.io/scrape": "true"
             }
           },
           "spec": {
@@ -220,6 +231,10 @@
                   {
                     "name": "https",
                     "containerPort": 8443
+                  },
+                  {
+                    "name": "prometheus",
+                    "containerPort": 10254
                   }
                 ],
                 "env": [

--- a/pkg/manifests/fixtures/nginx/no-ownership.json
+++ b/pkg/manifests/fixtures/nginx/no-ownership.json
@@ -158,6 +158,10 @@
         "creationTimestamp": null,
         "labels": {
           "app.kubernetes.io/managed-by": "aks-app-routing-operator"
+        },
+        "annotations": {
+          "prometheus.io/port": "10254",
+          "prometheus.io/scrape": "true"
         }
       },
       "spec": {
@@ -171,6 +175,11 @@
             "name": "https",
             "port": 443,
             "targetPort": "https"
+          },
+          {
+            "name": "prometheus",
+            "port": 10254,
+            "targetPort": "prometheus"
           }
         ],
         "selector": {
@@ -207,7 +216,9 @@
               "app": "nginx"
             },
             "annotations": {
-              "openservicemesh.io/sidecar-injection": "enabled"
+              "openservicemesh.io/sidecar-injection": "enabled",
+              "prometheus.io/port": "10254",
+              "prometheus.io/scrape": "true"
             }
           },
           "spec": {
@@ -233,6 +244,10 @@
                   {
                     "name": "https",
                     "containerPort": 8443
+                  },
+                  {
+                    "name": "prometheus",
+                    "containerPort": 10254
                   }
                 ],
                 "env": [

--- a/pkg/manifests/fixtures/nginx/optional-features-disabled.json
+++ b/pkg/manifests/fixtures/nginx/optional-features-disabled.json
@@ -158,6 +158,10 @@
         "creationTimestamp": null,
         "labels": {
           "app.kubernetes.io/managed-by": "aks-app-routing-operator"
+        },
+        "annotations": {
+          "prometheus.io/port": "10254",
+          "prometheus.io/scrape": "true"
         }
       },
       "spec": {
@@ -171,6 +175,11 @@
             "name": "https",
             "port": 443,
             "targetPort": "https"
+          },
+          {
+            "name": "prometheus",
+            "port": 10254,
+            "targetPort": "prometheus"
           }
         ],
         "selector": {
@@ -205,6 +214,10 @@
             "creationTimestamp": null,
             "labels": {
               "app": "nginx"
+            },
+            "annotations": {
+              "prometheus.io/port": "10254",
+              "prometheus.io/scrape": "true"
             }
           },
           "spec": {
@@ -230,6 +243,10 @@
                   {
                     "name": "https",
                     "containerPort": 8443
+                  },
+                  {
+                    "name": "prometheus",
+                    "containerPort": 10254
                   }
                 ],
                 "env": [


### PR DESCRIPTION
# Description

This allows users to easily consume web app routing prometheus metrics. It follows the guidance in the [nginx docs](https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/monitoring.md).

It won't disrupt or change the experience for users not using Prometheus in any way.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

We should document this feature on our next release with examples.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Is it a breaking change which will impact consuming tool(s)?

- [x] Tested locally
- [x] Unit tested
- [x] E2e tested

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
