### PR TITLE
Adding Ingress Controller Label for Metrics

### DIFF
--- a/pkg/manifests/fixtures/nginx/full.json
+++ b/pkg/manifests/fixtures/nginx/full.json
@@ -241,7 +241,7 @@
         "creationTimestamp": null,
         "labels": {
           "app.kubernetes.io/managed-by": "aks-app-routing-operator",
-          "app.kubernetes.io/component" : "aks-app-routing-operator-ingress-controller"
+          "app.kubernetes.io/component" : "ingress-controller"
         },
         "ownerReferences": [
           {

--- a/pkg/manifests/fixtures/nginx/full.json
+++ b/pkg/manifests/fixtures/nginx/full.json
@@ -240,7 +240,8 @@
         "namespace": "test-namespace",
         "creationTimestamp": null,
         "labels": {
-          "app.kubernetes.io/managed-by": "aks-app-routing-operator"
+          "app.kubernetes.io/managed-by": "aks-app-routing-operator",
+          "app.kubernetes.io/component" : "aks-app-routing-operator-ingress-controller"
         },
         "ownerReferences": [
           {

--- a/pkg/manifests/fixtures/nginx/internal.json
+++ b/pkg/manifests/fixtures/nginx/internal.json
@@ -244,7 +244,7 @@
         "creationTimestamp": null,
         "labels": {
           "app.kubernetes.io/managed-by": "aks-app-routing-operator",
-          "app.kubernetes.io/component" : "aks-app-routing-operator-ingress-controller"
+          "app.kubernetes.io/component" : "ingress-controller"
         },
         "ownerReferences": [
           {

--- a/pkg/manifests/fixtures/nginx/internal.json
+++ b/pkg/manifests/fixtures/nginx/internal.json
@@ -243,7 +243,8 @@
         "namespace": "test-namespace",
         "creationTimestamp": null,
         "labels": {
-          "app.kubernetes.io/managed-by": "aks-app-routing-operator"
+          "app.kubernetes.io/managed-by": "aks-app-routing-operator",
+          "app.kubernetes.io/component" : "aks-app-routing-operator-ingress-controller"
         },
         "ownerReferences": [
           {

--- a/pkg/manifests/fixtures/nginx/kube-system.json
+++ b/pkg/manifests/fixtures/nginx/kube-system.json
@@ -187,7 +187,8 @@
         "namespace": "kube-system",
         "creationTimestamp": null,
         "labels": {
-          "app.kubernetes.io/managed-by": "aks-app-routing-operator"
+          "app.kubernetes.io/managed-by": "aks-app-routing-operator",
+          "app.kubernetes.io/component" : "aks-app-routing-operator-ingress-controller"
         }
       },
       "spec": {

--- a/pkg/manifests/fixtures/nginx/kube-system.json
+++ b/pkg/manifests/fixtures/nginx/kube-system.json
@@ -188,7 +188,7 @@
         "creationTimestamp": null,
         "labels": {
           "app.kubernetes.io/managed-by": "aks-app-routing-operator",
-          "app.kubernetes.io/component" : "aks-app-routing-operator-ingress-controller"
+          "app.kubernetes.io/component" : "ingress-controller"
         }
       },
       "spec": {

--- a/pkg/manifests/fixtures/nginx/no-ownership.json
+++ b/pkg/manifests/fixtures/nginx/no-ownership.json
@@ -200,7 +200,8 @@
         "namespace": "test-namespace",
         "creationTimestamp": null,
         "labels": {
-          "app.kubernetes.io/managed-by": "aks-app-routing-operator"
+          "app.kubernetes.io/managed-by": "aks-app-routing-operator",
+          "app.kubernetes.io/component" : "aks-app-routing-operator-ingress-controller"
         }
       },
       "spec": {

--- a/pkg/manifests/fixtures/nginx/no-ownership.json
+++ b/pkg/manifests/fixtures/nginx/no-ownership.json
@@ -201,7 +201,7 @@
         "creationTimestamp": null,
         "labels": {
           "app.kubernetes.io/managed-by": "aks-app-routing-operator",
-          "app.kubernetes.io/component" : "aks-app-routing-operator-ingress-controller"
+          "app.kubernetes.io/component" : "ingress-controller"
         }
       },
       "spec": {

--- a/pkg/manifests/fixtures/nginx/optional-features-disabled.json
+++ b/pkg/manifests/fixtures/nginx/optional-features-disabled.json
@@ -200,7 +200,8 @@
         "namespace": "test-namespace",
         "creationTimestamp": null,
         "labels": {
-          "app.kubernetes.io/managed-by": "aks-app-routing-operator"
+          "app.kubernetes.io/managed-by": "aks-app-routing-operator",
+          "app.kubernetes.io/component" : "aks-app-routing-operator-ingress-controller"
         }
       },
       "spec": {

--- a/pkg/manifests/fixtures/nginx/optional-features-disabled.json
+++ b/pkg/manifests/fixtures/nginx/optional-features-disabled.json
@@ -201,7 +201,7 @@
         "creationTimestamp": null,
         "labels": {
           "app.kubernetes.io/managed-by": "aks-app-routing-operator",
-          "app.kubernetes.io/component" : "aks-app-routing-operator-ingress-controller"
+          "app.kubernetes.io/component" : "ingress-controller"
         }
       },
       "spec": {

--- a/pkg/manifests/nginx.go
+++ b/pkg/manifests/nginx.go
@@ -256,6 +256,8 @@ func newNginxIngressControllerService(conf *config.Config, ingressConfig *NginxI
 }
 
 func newNginxIngressControllerDeployment(conf *config.Config, ingressConfig *NginxIngressConfig) *appsv1.Deployment {
+	ingressControllerLabels := topLevelLabels
+	ingressControllerLabels["app.kubernetes.io/component"] = "aks-app-routing-operator-ingress-controller"
 	podAnnotations := map[string]string{}
 	if !conf.DisableOSM {
 		podAnnotations["openservicemesh.io/sidecar-injection"] = "enabled"
@@ -273,7 +275,7 @@ func newNginxIngressControllerDeployment(conf *config.Config, ingressConfig *Ngi
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      ingressConfig.ResourceName,
 			Namespace: conf.NS,
-			Labels:    topLevelLabels,
+			Labels:    ingressControllerLabels,
 		},
 		Spec: appsv1.DeploymentSpec{
 			RevisionHistoryLimit: util.Int32Ptr(2),

--- a/pkg/manifests/nginx.go
+++ b/pkg/manifests/nginx.go
@@ -256,7 +256,12 @@ func newNginxIngressControllerService(conf *config.Config, ingressConfig *NginxI
 }
 
 func newNginxIngressControllerDeployment(conf *config.Config, ingressConfig *NginxIngressConfig) *appsv1.Deployment {
-	ingressControllerLabels := topLevelLabels
+	ingressControllerLabels := make(map[string]string)
+
+	for k, v := range topLevelLabels {
+		ingressControllerLabels[k] = v
+	}
+
 	ingressControllerLabels["app.kubernetes.io/component"] = "ingress-controller"
 	podAnnotations := map[string]string{}
 	if !conf.DisableOSM {

--- a/pkg/manifests/nginx.go
+++ b/pkg/manifests/nginx.go
@@ -257,7 +257,7 @@ func newNginxIngressControllerService(conf *config.Config, ingressConfig *NginxI
 
 func newNginxIngressControllerDeployment(conf *config.Config, ingressConfig *NginxIngressConfig) *appsv1.Deployment {
 	ingressControllerLabels := topLevelLabels
-	ingressControllerLabels["app.kubernetes.io/component"] = "aks-app-routing-operator-ingress-controller"
+	ingressControllerLabels["app.kubernetes.io/component"] = "ingress-controller"
 	podAnnotations := map[string]string{}
 	if !conf.DisableOSM {
 		podAnnotations["openservicemesh.io/sidecar-injection"] = "enabled"


### PR DESCRIPTION
# Description

Adding a label to our ingress controller deployments so they can be detected by our monitors for readiness/status. Future additions will let users deploy controllers with many configuration options (like namespace, name, etc.). Monitors currently can simply look for a controller deployment by name + namespace since only one controller is deployed but this changes in the future. Labels fix this problem.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
This should not impact consuming tools. It will only be fully tested once the accompanying metric has been configured, but in the meantime, unit tests have been accordingly modified + e2e is passing.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
