### PR TITLE
adds cloudName to kv spc reconciler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,6 @@ clean-private:
 
 clean-all: clean-public clean-private
 
-# modify the Azure location by exporting an environment variable
-# export TF_VAR_location="East US"
 dev-public:
 	terraform --version
 	cd devenv && mkdir -p state && cd public_cluster_tf && terraform init && terraform apply -auto-approve

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@ clean-private:
 
 clean-all: clean-public clean-private
 
+# modify the Azure location by exporting an environment variable
+# export TF_VAR_location="East US"
 dev-public:
 	terraform --version
 	cd devenv && mkdir -p state && cd public_cluster_tf && terraform init && terraform apply -auto-approve

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Kubernetes operator that manages resources related to AKS Application Routing functionality.
 
+## Docs
+
+View the [docs](docs/) folder for more information.
+
 ## Contributing
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a
@@ -15,6 +19,7 @@ provided by the bot. You will only need to do this once across all repos using o
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
 contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+
 
 ## Trademarks
 

--- a/README.md
+++ b/README.md
@@ -16,23 +16,6 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
 contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
 
-## E2E
-This project leverages Terraform and the local user's Azure credentials to run an extensive E2E suite.
-
-### Public Cluster/Public DNS Zone
-The process to run an E2E test for public clusters is as follows:
-1. Run `make clean-public` or `make clean-all` to clear any preexisting Terraform state for the public cluster dev environment.
-2. Run `make dev-public` to deploy all Azure resources necessary to run a full suite, including a cluster with the add-on enabled. IMPORTANT: this does not start the add-on. The next step needs to be run for the add-on to be fully deployed with the correct image.
-3. Run `make push` to build the add-on image according to the user's local state/branch and push it to the add-on deployment. This step can be re-run when changes to the local add-on are made and the user wishes to manually test those changes on a cluster.
-4. Run `make e2e` to deploy the e2e tester job, which will run the e2e test suite inside the cluster.
-
-### Private Cluster/Private DNS Zone
-The process to run an E2E test for private clusters is as follows:
-1. Run `make clean-private` or `make clean-all` to clear any preexisting Terraform state for the private cluster dev environment.
-2. Run `make dev-private` to deploy all Azure resources necessary to run a full suite, including a cluster with the add-on enabled. IMPORTANT: this does not start the add-on. The next step needs to be run for the add-on to be fully deployed with the correct image.
-3. Run `make push` to build the add-on image according to the user's local state/branch and push it to the add-on deployment. This step can be re-run when changes to the local add-on are made and the user wishes to manually test those changes on a cluster.
-4. Run `make e2e` to deploy the e2e tester job, which will run the e2e test suite inside the cluster.
-
 ## Trademarks
 
 This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
 contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
 
-
 ## Trademarks
 
 This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft 

--- a/devenv/private_cluster_tf/main.tf
+++ b/devenv/private_cluster_tf/main.tf
@@ -1,3 +1,9 @@
+variable "location" {
+  type = string
+  description = "The Azure Region in which resources will be created"
+  default = "South Central US"
+}
+
 terraform {
   required_providers {
     azurerm = {
@@ -42,7 +48,7 @@ data "azurerm_subscription" "current" {
 
 resource "azurerm_resource_group" "rg" {
   name     = "app-routing-dev-${random_string.random.result}a"
-  location = "South Central US"
+  location = var.location
   tags = {
     deletion_due_time  = time_static.provisiontime.unix + 36000, // keep resources for 10hr
     deletion_marked_by = "gc",

--- a/devenv/public_cluster_tf/main.tf
+++ b/devenv/public_cluster_tf/main.tf
@@ -42,7 +42,7 @@ data "azurerm_subscription" "current" {
 
 resource "azurerm_resource_group" "rg" {
   name     = "app-routing-dev-${random_string.random.result}a"
-  location = "South Central US"
+  location = "USGov Texas"
   tags = {
     deletion_due_time  = time_static.provisiontime.unix + 36000, // keep resources for 10hr
     deletion_marked_by = "gc",

--- a/devenv/public_cluster_tf/main.tf
+++ b/devenv/public_cluster_tf/main.tf
@@ -42,7 +42,7 @@ data "azurerm_subscription" "current" {
 
 resource "azurerm_resource_group" "rg" {
   name     = "app-routing-dev-${random_string.random.result}a"
-  location = "USGov Texas"
+  location = "South Central US"
   tags = {
     deletion_due_time  = time_static.provisiontime.unix + 36000, // keep resources for 10hr
     deletion_marked_by = "gc",

--- a/devenv/public_cluster_tf/main.tf
+++ b/devenv/public_cluster_tf/main.tf
@@ -1,3 +1,9 @@
+variable "location" {
+  type = string
+  description = "The Azure Region in which resources will be created"
+  default = "South Central US"
+}
+
 terraform {
   required_providers {
     azurerm = {
@@ -42,7 +48,7 @@ data "azurerm_subscription" "current" {
 
 resource "azurerm_resource_group" "rg" {
   name     = "app-routing-dev-${random_string.random.result}a"
-  location = "South Central US"
+  location = var.location
   tags = {
     deletion_due_time  = time_static.provisiontime.unix + 36000, // keep resources for 10hr
     deletion_marked_by = "gc",

--- a/docs/validating.md
+++ b/docs/validating.md
@@ -10,7 +10,7 @@ You can easily provision a development environment to test your changes on.
 1. `az login` logs in the account you want to use
 2. `az account set --subscription <subscription>` sets the subscription to use
 4. `make clean-public` clears preexisitng development state
-5. `make dev-public` provisions requires resources
+5. `make dev-public` provisions required resources
 6. `make push` builds and pushes the operator image to the cluster
 
 You can test with a private cluster by replacing the `-public` suffix with `-private` in the commands.

--- a/docs/validating.md
+++ b/docs/validating.md
@@ -1,0 +1,27 @@
+
+# Validating
+
+Before submitting a pull request, you need to ensure that your changes work and don't cause regressions.
+
+## Development Environment 
+
+You can easily provision a development environment to test your changes on.
+
+1. `az login` logs in the account you want to use
+2. `az account set --subscription <subscription>` sets the subscription to use
+4. `make clean-public` clears preexisitng development state
+5. `make dev-public` provisions requires resources
+6. `make push` builds and pushes the operator image to the cluster
+
+You can test with a private cluster by replacing the `-public` suffix with `-private` in the commands.
+
+Region can be specified by exporting an env variable before running the `make dev-public` command. `export TF_VAR_location="East US"` sets the location to East US.
+
+This development environment is useful for manually interacting with App Routing and automated E2E testing.
+
+## E2E
+
+E2E is a set of automated tests ran against a development environment that validate the functionality of the operator. 
+
+A prerequisite for running E2E is to have a [Development Environment](#development-environment) running. Once your development environment is ready, you can simply run E2E with `make e2e`.
+

--- a/go.mod
+++ b/go.mod
@@ -14,10 +14,11 @@ require (
 	k8s.io/client-go v0.26.1
 	k8s.io/klog/v2 v2.80.1
 	sigs.k8s.io/controller-runtime v0.14.5
-	sigs.k8s.io/secrets-store-csi-driver v0.0.24-0.20211001213819-41b8bb9bf89a
+	sigs.k8s.io/secrets-store-csi-driver v1.2.4
 )
 
 require (
+	github.com/Azure/secrets-store-csi-driver-provider-azure v1.4.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
@@ -52,7 +53,7 @@ require (
 	github.com/rogpeppe/go-internal v1.8.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
-	go.uber.org/multierr v1.7.0 // indirect
+	go.uber.org/multierr v1.8.0 // indirect
 	golang.org/x/net v0.7.0 // indirect
 	golang.org/x/oauth2 v0.4.0 // indirect
 	golang.org/x/sys v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+github.com/Azure/secrets-store-csi-driver-provider-azure v1.4.1 h1:24/mZ06Uzu8EkdgJj8zcy5C3Ipsg1doM62hx0WPscNU=
+github.com/Azure/secrets-store-csi-driver-provider-azure v1.4.1/go.mod h1:xUXKV8vOut59vIrFhyEY+4PgiK2LXkP10BtI+2y8VXM=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
@@ -174,6 +176,7 @@ go.uber.org/atomic v1.10.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0
 go.uber.org/goleak v1.2.0 h1:xqgm/S+aQvhWFTtR0XK3Jvg7z8kGV8P4X14IzwN3Eqk=
 go.uber.org/multierr v1.7.0 h1:zaiO/rmgFjbmCXdSYJWQcdvOCsthmdaHfr3Gm2Kx4Ec=
 go.uber.org/multierr v1.7.0/go.mod h1:7EAYxJLBy9rStEaz58O2t4Uvip6FSURkq8/ppBp95ak=
+go.uber.org/multierr v1.8.0/go.mod h1:7EAYxJLBy9rStEaz58O2t4Uvip6FSURkq8/ppBp95ak=
 go.uber.org/zap v1.24.0 h1:FiJd5l1UOLj0wCgbSE0rwwXHzEdAZS6hiiSnxJN/D60=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
@@ -319,6 +322,8 @@ sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMm
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
 sigs.k8s.io/secrets-store-csi-driver v0.0.24-0.20211001213819-41b8bb9bf89a h1:Eoeh8Ou6tiKZw8VJ1zFHg0OXv8b92oqtzA0A//ANMXo=
 sigs.k8s.io/secrets-store-csi-driver v0.0.24-0.20211001213819-41b8bb9bf89a/go.mod h1:OtKvgLPVFM2GLMBo6Hx33TGWzDo0GrQkW5aCpWfepzs=
+sigs.k8s.io/secrets-store-csi-driver v1.2.4 h1:2DjC2dbhOHWb62i5naX7wVj2i9Suo5c8KzBKd5mRVvk=
+sigs.k8s.io/secrets-store-csi-driver v1.2.4/go.mod h1:oUsYHi+fhJjUEvtxm02XDsXQ0lZw8XPWROyhhAa+BuY=
 sigs.k8s.io/structured-merge-diff/v4 v4.2.3 h1:PRbqxJClWWYMNV1dhaG4NsibJbArud9kFxnAMREiWFE=
 sigs.k8s.io/structured-merge-diff/v4 v4.2.3/go.mod h1:qjx8mGObPmV2aSZepjQjbmb2ihdVs8cGKBraizNC69E=
 sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=

--- a/pkg/controller/keyvault/ingress_secret_provider_class.go
+++ b/pkg/controller/keyvault/ingress_secret_provider_class.go
@@ -21,10 +21,7 @@ import (
 
 	"github.com/Azure/aks-app-routing-operator/pkg/config"
 	"github.com/Azure/aks-app-routing-operator/pkg/util"
-)
-
-const (
-	cloudNameKey = "cloudName"
+	kvcsi "github.com/Azure/secrets-store-csi-driver-provider-azure/pkg/provider/types"
 )
 
 // IngressSecretProviderClassReconciler manages a SecretProviderClass for each ingress resource that
@@ -177,7 +174,7 @@ func (i *IngressSecretProviderClassReconciler) buildSPC(ing *netv1.Ingress, spc 
 	}
 
 	if i.config.Cloud != "" {
-		spc.Spec.Parameters[cloudNameKey] = i.config.Cloud
+		spc.Spec.Parameters[kvcsi.CloudNameParameter] = i.config.Cloud
 	}
 
 	return true, nil

--- a/pkg/controller/keyvault/ingress_secret_provider_class.go
+++ b/pkg/controller/keyvault/ingress_secret_provider_class.go
@@ -23,6 +23,10 @@ import (
 	"github.com/Azure/aks-app-routing-operator/pkg/util"
 )
 
+const (
+	cloudNameKey = "cloudName"
+)
+
 // IngressSecretProviderClassReconciler manages a SecretProviderClass for each ingress resource that
 // references a Keyvault certificate. The SPC is used to mirror the Keyvault values into a k8s secret
 // so that it can be used by the ingress controller.
@@ -162,6 +166,7 @@ func (i *IngressSecretProviderClassReconciler) buildSPC(ing *netv1.Ingress, spc 
 				},
 			},
 		}},
+		// https://azure.github.io/secrets-store-csi-driver-provider-azure/docs/getting-started/usage/#create-your-own-secretproviderclass-object
 		Parameters: map[string]string{
 			"keyvaultName":           vaultName,
 			"useVMManagedIdentity":   "true",
@@ -170,5 +175,10 @@ func (i *IngressSecretProviderClassReconciler) buildSPC(ing *netv1.Ingress, spc 
 			"objects":                string(objects),
 		},
 	}
+
+	if i.config.Cloud != "" {
+		spc.Spec.Parameters[cloudNameKey] = i.config.Cloud
+	}
+
 	return true, nil
 }

--- a/pkg/controller/keyvault/ingress_secret_provider_class_test.go
+++ b/pkg/controller/keyvault/ingress_secret_provider_class_test.go
@@ -23,6 +23,7 @@ import (
 	secv1 "sigs.k8s.io/secrets-store-csi-driver/apis/v1"
 
 	"github.com/Azure/aks-app-routing-operator/pkg/config"
+	kvcsi "github.com/Azure/secrets-store-csi-driver-provider-azure/pkg/provider/types"
 )
 
 func TestIngressSecretProviderClassReconcilerIntegration(t *testing.T) {
@@ -265,7 +266,7 @@ func TestIngressSecretProviderClassReconcilerBuildSPCCloud(t *testing.T) {
 			require.NoError(t, err, "building SPC should not error")
 			require.True(t, ok, "SPC should be built")
 
-			spcCloud, ok := spc.Spec.Parameters[cloudNameKey]
+			spcCloud, ok := spc.Spec.Parameters[kvcsi.CloudNameParameter]
 			require.Equal(t, c.expected, ok, "SPC cloud annotation unexpected")
 			require.Equal(t, c.spcCloud, spcCloud, "SPC cloud annotation doesn't match")
 		})

--- a/pkg/controller/keyvault/ingress_secret_provider_class_test.go
+++ b/pkg/controller/keyvault/ingress_secret_provider_class_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 	netv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -212,4 +213,61 @@ func TestIngressSecretProviderClassReconcilerBuildSPCInvalidURLs(t *testing.T) {
 		assert.False(t, ok)
 		require.EqualError(t, err, "invalid secret uri: http://test.com/foo")
 	})
+}
+
+func TestIngressSecretProviderClassReconcilerBuildSPCCloud(t *testing.T) {
+	cases := []struct {
+		name, configCloud, spcCloud string
+		expected                    bool
+	}{
+		{
+			name:        "empty config cloud",
+			configCloud: "",
+			expected:    false,
+		},
+		{
+			name:        "public cloud",
+			configCloud: "AzurePublicCloud",
+			spcCloud:    "AzurePublicCloud",
+			expected:    true,
+		},
+		{
+			name:        "sov cloud",
+			configCloud: "AzureUSGovernmentCloud",
+			spcCloud:    "AzureUSGovernmentCloud",
+			expected:    true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ingressClass := "webapprouting.kubernetes.azure.com"
+			i := &IngressSecretProviderClassReconciler{
+				config: &config.Config{
+					Cloud: c.configCloud,
+				},
+				ingressManager: NewIngressManager(map[string]struct{}{ingressClass: {}}),
+			}
+
+			ing := &netv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"kubernetes.azure.com/tls-cert-keyvault-uri": "https://test.vault.azure.net/secrets/test-secret",
+					},
+				},
+				Spec: netv1.IngressSpec{
+					IngressClassName: &ingressClass,
+				},
+			}
+
+			spc := &secv1.SecretProviderClass{}
+			ok, err := i.buildSPC(ing, spc)
+			require.NoError(t, err, "building SPC should not error")
+			require.True(t, ok, "SPC should be built")
+
+			spcCloud, ok := spc.Spec.Parameters[cloudNameKey]
+			require.Equal(t, c.expected, ok, "SPC cloud annotation unexpected")
+			require.Equal(t, c.spcCloud, spcCloud, "SPC cloud annotation doesn't match")
+		})
+	}
 }


### PR DESCRIPTION
# Description

This change adds cloudName to the kv spc reconciler which results in the kv spc generated by war to work in sov clouds.

It also includes a small change to our dev environment allowing us to specify the location.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested manually in sov clouds. Plan to add this to rp e2e tests as well.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
