### PR TITLE
switch release tag to be semver

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,11 +8,6 @@ on:
       sha:
         description: 'Commit SHA to release. Example: 7dec363daaca95c59f68607ac1f29a12bc0b195b'
         required: true
-      update:
-        description: 'Update the release'
-        type: boolean
-        required: false
-        default: false
 
 permissions:
   id-token: write
@@ -50,14 +45,6 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Build and push image
-        env:
-          SHA: ${{ inputs.sha }}
-        run: |
-          TAG="${{ secrets.AZURE_REGISTRY_SERVER }}/public/aks/aks-app-routing-operator:sha-$SHA"
-          az acr login -n ${{ secrets.AZURE_REGISTRY_SERVER }}
-          docker buildx build --platform "amd64,arm64" --tag "${TAG}" --output type=registry .
-
       - name: Create or update release
         uses: ncipollo/release-action@a2e71bdd4e7dab70ca26a852f29600c98b33153e # v1.12.0
         with:
@@ -68,4 +55,15 @@ jobs:
           prerelease: false
           draft: false
           token: ${{ secrets.GITHUB_TOKEN }}
-          allowUpdates: ${{ inputs.update }}
+          allowUpdates: false
+
+        # Push happens after creating GitHub release so we don't overwrite an image.
+        # Create release step doesn't allow for tag updates so we will never push
+        # to an image that already exists.
+      - name: Build and push image
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          TAG="${{ secrets.AZURE_REGISTRY_SERVER }}/public/aks/aks-app-routing-operator:$VERSION"
+          az acr login -n ${{ secrets.AZURE_REGISTRY_SERVER }}
+          docker buildx build --platform "amd64,arm64" --tag "${TAG}" --output type=registry .

--- a/docs/release.md
+++ b/docs/release.md
@@ -10,3 +10,7 @@ A prerequisite to creating a release is updating the [CHANGELOG.md](../CHANGELOG
 After the CHANGELOG has been updated, you can start a release by going to the `Actions` tab and selecting `Release` on the left. Then click `Run workflow` and input the required parameters. It's very important that the SHA used is one that matches the changes detailed in the CHANGELOG exactly.
 
 You can ensure the release workflow ran successfully by watching the workflow then verifying that both the image push and GitHub release were successful. 
+
+## Hotfix
+
+In the unlikely event that a hotfix is needed, you can create a hotfix release through the same steps detailed above. The semantic version will include a meta suffix of `+hotfix-<number>`. For example, the first hotfix of version `1.0.0` would be `1.0.0+hotfix.1`. The hotfix number should be incremented for each hotfix release.


### PR DESCRIPTION
# Description

Swaps the release tag of released image to be the semantic version.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested on a fork.
- https://github.com/aksatlanta-testing/anotherolivertest/actions/runs/5489075203
- https://github.com/aksatlanta-testing/anotherolivertest/releases

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
