### PR TITLE
add controller name interface to all controllers

### DIFF
--- a/pkg/controller/common/cleaner_test.go
+++ b/pkg/controller/common/cleaner_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/Azure/aks-app-routing-operator/pkg/controller/controllername"
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -188,7 +189,6 @@ func TestCleanType(t *testing.T) {
 		}
 
 		c := &cleaner{
-			name:      "test-name",
 			dynamic:   d,
 			clientset: fakeClientset(),
 			logger:    logr.Discard(),
@@ -242,7 +242,7 @@ func AssertAction(t *testing.T, got []k8stesting.Action, expected k8stesting.Act
 func TestNewCleaner(t *testing.T) {
 	m, err := manager.New(restConfig, manager.Options{MetricsBindAddress: "0"})
 	require.NoError(t, err)
-	err = NewCleaner(m, "test-new-cleaner", RetrieverEmpty())
+	err = NewCleaner(m, controllername.New("test"), RetrieverEmpty())
 	require.NoError(t, err)
 }
 
@@ -266,7 +266,7 @@ func TestClean(t *testing.T) {
 		{
 			name: "nil retriver",
 			c: &cleaner{
-				name:      "test-name",
+				name:      controllername.New("test"),
 				dynamic:   d,
 				clientset: fakeClientset(),
 				logger:    logr.Discard(),
@@ -276,7 +276,7 @@ func TestClean(t *testing.T) {
 		{
 			name: "runs clean without err",
 			c: &cleaner{
-				name:      "test-name",
+				name:      controllername.New("test"),
 				dynamic:   d,
 				clientset: fakeClientset(),
 				logger:    logr.Discard(),
@@ -315,7 +315,7 @@ func TestCleanerStart(t *testing.T) {
 		{
 			name: "failing to start",
 			c: &cleaner{
-				name:       "test-name",
+				name:       controllername.New("test"),
 				dynamic:    d,
 				clientset:  fakeClientset(),
 				logger:     logr.Discard(),
@@ -326,7 +326,7 @@ func TestCleanerStart(t *testing.T) {
 		{
 			name: "starts cleaner",
 			c: &cleaner{
-				name:       "test-name",
+				name:       controllername.New("test"),
 				dynamic:    d,
 				clientset:  fakeClientset(),
 				logger:     logr.Discard(),

--- a/pkg/controller/common/resource_reconciler.go
+++ b/pkg/controller/common/resource_reconciler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/Azure/aks-app-routing-operator/pkg/controller/controllername"
 	"github.com/Azure/aks-app-routing-operator/pkg/controller/metrics"
 	"github.com/Azure/aks-app-routing-operator/pkg/util"
 	"github.com/go-logr/logr"
@@ -13,7 +14,7 @@ import (
 )
 
 type resourceReconciler struct {
-	name                    string
+	name                    controllername.ControllerNamer
 	client                  client.Client
 	logger                  logr.Logger
 	interval, retryInterval time.Duration
@@ -21,12 +22,12 @@ type resourceReconciler struct {
 }
 
 // NewResourceReconciler creates a reconciler that continuously ensures that the provided resources are provisioned
-func NewResourceReconciler(manager ctrl.Manager, name string, resources []client.Object, reconcileInterval time.Duration) error {
+func NewResourceReconciler(manager ctrl.Manager, name controllername.ControllerNamer, resources []client.Object, reconcileInterval time.Duration) error {
 	metrics.InitControllerMetrics(name)
 	rr := &resourceReconciler{
 		name:          name,
 		client:        manager.GetClient(),
-		logger:        manager.GetLogger().WithName(name),
+		logger:        name.AddToLogger(manager.GetLogger()),
 		interval:      reconcileInterval,
 		retryInterval: time.Second,
 		resources:     resources,

--- a/pkg/controller/common/resource_reconciler_test.go
+++ b/pkg/controller/common/resource_reconciler_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Azure/aks-app-routing-operator/pkg/controller/controllername"
 	"github.com/Azure/aks-app-routing-operator/pkg/controller/metrics"
 	"github.com/Azure/aks-app-routing-operator/pkg/controller/testutils"
 	"github.com/go-logr/logr"
@@ -21,7 +22,7 @@ func TestResourceReconcilerEmpty(t *testing.T) {
 	c := fake.NewClientBuilder().Build()
 
 	rr := &resourceReconciler{
-		name:      "test-name",
+		name:      controllername.New("test", "resource", "reconciler"),
 		client:    c,
 		logger:    logr.Discard(),
 		resources: []client.Object{},
@@ -48,7 +49,7 @@ func TestResourceReconcilerIntegration(t *testing.T) {
 	}
 
 	rr := &resourceReconciler{
-		name:      "test-name",
+		name:      controllername.New("test"),
 		client:    c,
 		logger:    logr.Discard(),
 		resources: []client.Object{obj},
@@ -97,7 +98,7 @@ func TestResourceReconcilerLeaderElection(t *testing.T) {
 func TestNewResourceReconciler(t *testing.T) {
 	m, err := manager.New(restConfig, manager.Options{MetricsBindAddress: "0"})
 	require.NoError(t, err)
-	err = NewResourceReconciler(m, "test-rr", nil, 1*time.Nanosecond)
+	err = NewResourceReconciler(m, controllername.New("test"), nil, 1*time.Nanosecond)
 	require.NoError(t, err)
 }
 
@@ -118,7 +119,7 @@ func TestResourceReconciler_DeletionTimestamp(t *testing.T) {
 	c := fake.NewClientBuilder().WithObjects(obj).Build()
 
 	rr := &resourceReconciler{
-		name:      "test-name",
+		name:      controllername.New("test", "name"),
 		client:    c,
 		logger:    logr.Discard(),
 		resources: []client.Object{obj},
@@ -155,7 +156,7 @@ func TestResourceReconciler_Start(t *testing.T) {
 	c := fake.NewClientBuilder().WithObjects(obj).Build()
 
 	rr := &resourceReconciler{
-		name:      "test-name",
+		name:      controllername.New("test", "name"),
 		client:    c,
 		logger:    logr.Discard(),
 		resources: []client.Object{obj},

--- a/pkg/controller/controllername/controllername.go
+++ b/pkg/controller/controllername/controllername.go
@@ -14,34 +14,39 @@ const (
 
 // ControllerNamer is an interface that returns the name of the controller in all necessary forms
 type ControllerNamer interface {
-	// String returns the name of the controller in a human readable form
+	// String returns the name of the controller in a human-readable form
 	String() string
 	// MetricsName returns the name of the controller in a form that can be used for Prometheus metrics, specifically as a Prometheus label https://prometheus.io/docs/practices/naming/#labels
 	MetricsName() string
 	// LoggerName returns the name of the controller in a form that can be used for logr logger naming
 	LoggerName() string
+	// AddToLogger adds controller name fields to the logger then returns the logger with the added fields
+	AddToLogger(l logr.Logger) logr.Logger
 }
 
 // controllerName ex. {"My","Controller", "Name"} ->  MyControllerName
 type controllerName []string
 
-// NewControllerName returns a new controllerName after taking input a slice of each word in the controller name
-func NewControllerName(name []string) controllerName {
-	cn := make(controllerName, len(name))
+// New returns a new controllerName after taking each word of the controller name as a separate argument
+func New(firstWord string, additionalWords ...string) controllerName { // using a non-variadic for the first word makes it impossible to accidentally pass no arguments in. Accepting variadic versus slices also helps with not accepting empty slices and is easier to use
+	cn := controllerName{clean(firstWord)}
 
-	for i, w := range name {
-		cn[i] = strip(strings.ToLower(w))
-
+	for _, w := range additionalWords {
+		cleaned := clean(w)
+		if cleaned != "" {
+			cn = append(cn, cleaned)
+		}
 	}
+
 	return cn
 }
 
-// strip removes spaces and non letters
-func strip(s string) string {
+// clean removes spaces and non letters and lowercases
+func clean(s string) string {
 	rr := make([]rune, 0, len(s))
 	for _, r := range s {
 		if unicode.IsLetter(r) {
-			rr = append(rr, r)
+			rr = append(rr, unicode.ToLower(r))
 		}
 	}
 	return string(rr)
@@ -59,10 +64,9 @@ func (c controllerName) String() string {
 	return strings.Join(c, " ")
 }
 
-// AddToLogger adds controller name fields to the logger then returns the logger with the added fields
-func AddToLogger(l logr.Logger, cn ControllerNamer) logr.Logger {
+func (c controllerName) AddToLogger(l logr.Logger) logr.Logger {
 	return l.
-		WithName(cn.LoggerName()).
-		WithValues("controller", cn.String()).
-		WithValues("controllerMetricsName", cn.MetricsName()) // include metrics name so we can automate creating queries that check Logs based on alerts
+		WithName(c.LoggerName()).
+		WithValues("controller", c.String()).
+		WithValues("controllerMetricsName", c.MetricsName()) // include metrics name, so we can automate creating queries that check Logs based on alerts
 }

--- a/pkg/controller/controllername/controllername.go
+++ b/pkg/controller/controllername/controllername.go
@@ -3,6 +3,8 @@ package controllername
 import (
 	"strings"
 	"unicode"
+
+	"github.com/go-logr/logr"
 )
 
 const (
@@ -10,14 +12,20 @@ const (
 	loggerNameDelimiter  = "-"
 )
 
+// ControllerNamer is an interface that returns the name of the controller in all necessary forms
 type ControllerNamer interface {
+	// String returns the name of the controller in a human readable form
+	String() string
+	// MetricsName returns the name of the controller in a form that can be used for Prometheus metrics, specifically as a Prometheus label https://prometheus.io/docs/practices/naming/#labels
 	MetricsName() string
+	// LoggerName returns the name of the controller in a form that can be used for logr logger naming
 	LoggerName() string
 }
 
 // controllerName ex. {"My","Controller", "Name"} ->  MyControllerName
 type controllerName []string
 
+// NewControllerName returns a new controllerName after taking input a slice of each word in the controller name
 func NewControllerName(name []string) controllerName {
 	cn := make(controllerName, len(name))
 
@@ -28,7 +36,7 @@ func NewControllerName(name []string) controllerName {
 	return cn
 }
 
-// Strip removes spaces and non letters
+// strip removes spaces and non letters
 func strip(s string) string {
 	rr := make([]rune, 0, len(s))
 	for _, r := range s {
@@ -45,4 +53,16 @@ func (c controllerName) MetricsName() string {
 
 func (c controllerName) LoggerName() string {
 	return strings.Join(c, loggerNameDelimiter)
+}
+
+func (c controllerName) String() string {
+	return strings.Join(c, " ")
+}
+
+// AddToLogger adds controller name fields to the logger then returns the logger with the added fields
+func AddToLogger(l logr.Logger, cn ControllerNamer) logr.Logger {
+	return l.
+		WithName(cn.LoggerName()).
+		WithValues("controller", cn.String()).
+		WithValues("controllerMetricsName", cn.MetricsName()) // include metrics name so we can automate creating queries that check Logs based on alerts
 }

--- a/pkg/controller/controllername/controllername_test.go
+++ b/pkg/controller/controllername/controllername_test.go
@@ -1,13 +1,13 @@
 package controllername
 
 import (
-	"github.com/stretchr/testify/require"
 	"regexp"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestMetricsName(t *testing.T) {
-
 	cn1 := NewControllerName([]string{"SomeFakeControllerName"})
 	cn2 := NewControllerName([]string{"Some", "Controller", "Name"})
 	cn3 := NewControllerName([]string{" SomeName", "Entered  ", "poorly"})
@@ -52,7 +52,42 @@ func TestLoggerName(t *testing.T) {
 	require.True(t, isBestPracticeLoggerName(loggerName4))
 	require.True(t, isBestPracticeLoggerName(loggerName5))
 	require.True(t, isBestPracticeLoggerName(loggerName6))
+}
 
+func TestControllerNameString(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		expected string
+	}{
+		{
+			name:     "single word",
+			input:    []string{"SomeFakeControllerName"},
+			expected: "somefakecontrollername",
+		},
+		{
+			name:     "multiple words",
+			input:    []string{"Some", "Controller", "Name"},
+			expected: "some controller name",
+		},
+		{
+			name:     "multiple words with spaces",
+			input:    []string{" SomeName", "Entered  ", "poorly"},
+			expected: "somename entered poorly",
+		},
+		{
+			name:     "multiple words with characters",
+			input:    []string{"special!@characters", "and", "numbers123"},
+			expected: "specialcharacters and numbers",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cn := NewControllerName(test.input)
+			require.Equal(t, test.expected, cn.String())
+		})
+	}
 }
 
 func TestStrip(t *testing.T) {
@@ -62,7 +97,7 @@ func TestStrip(t *testing.T) {
 	require.Equal(t, striped, "abc")
 }
 
-// IsPrometheusBestPracticeName - function returns true if the name given matches best practices for prometheus name, i.e. snake_case
+// isPrometheusBestPracticeName - function returns true if the name given matches best practices for prometheus name, i.e. snake_case
 func isPrometheusBestPracticeName(controllerName string) bool {
 	pattern := "^[a-z]+(_[a-z]+)*$"
 	match, _ := regexp.MatchString(pattern, controllerName)
@@ -70,7 +105,7 @@ func isPrometheusBestPracticeName(controllerName string) bool {
 	return match
 }
 
-// IsBestPracticeLoggerName - function returns true if the name given matches best practices for prometheus name, i.e. kebab-case
+// isBestPracticeLoggerName - function returns true if the name given matches best practices for prometheus name, i.e. kebab-case
 func isBestPracticeLoggerName(controllerName string) bool {
 	pattern := "^[a-z]+(-[a-z]+)*$"
 	match, _ := regexp.MatchString(pattern, controllerName)

--- a/pkg/controller/controllername/controllername_test.go
+++ b/pkg/controller/controllername/controllername_test.go
@@ -8,12 +8,13 @@ import (
 )
 
 func TestMetricsName(t *testing.T) {
-	cn1 := NewControllerName([]string{"SomeFakeControllerName"})
-	cn2 := NewControllerName([]string{"Some", "Controller", "Name"})
-	cn3 := NewControllerName([]string{" SomeName", "Entered  ", "poorly"})
-	cn4 := NewControllerName([]string{"Some Spaces"})
-	cn5 := NewControllerName([]string{"Too  Many       Spaces"})
-	cn6 := NewControllerName([]string{"special!@characters"})
+
+	cn1 := New("SomeFakeControllerName")
+	cn2 := New("Some", "Controller", "Name")
+	cn3 := New(" SomeName", "Entered  ", "poorly")
+	cn4 := New("Some Spaces")
+	cn5 := New("Too  Many       Spaces")
+	cn6 := New("special!@characters")
 
 	metricName1 := cn1.MetricsName()
 	metricName2 := cn2.MetricsName()
@@ -32,12 +33,12 @@ func TestMetricsName(t *testing.T) {
 }
 
 func TestLoggerName(t *testing.T) {
-	cn1 := NewControllerName([]string{"SomeFakeControllerName"})
-	cn2 := NewControllerName([]string{"Some", "Controller", "Name"})
-	cn3 := NewControllerName([]string{" SomeName", "Entered  ", "poorly"})
-	cn4 := NewControllerName([]string{"Some Spaces"})
-	cn5 := NewControllerName([]string{"Too  Many       Spaces"})
-	cn6 := NewControllerName([]string{"special!@characters"})
+	cn1 := New("SomeFakeControllerName")
+	cn2 := New("Some", "Controller", "Name")
+	cn3 := New(" SomeName", "Entered  ", "poorly")
+	cn4 := New("Some Spaces")
+	cn5 := New("Too  Many       Spaces")
+	cn6 := New("special!@characters")
 
 	loggerName1 := cn1.LoggerName()
 	loggerName2 := cn2.LoggerName()
@@ -84,7 +85,7 @@ func TestControllerNameString(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			cn := NewControllerName(test.input)
+			cn := New(test.input[0], test.input[1:]...)
 			require.Equal(t, test.expected, cn.String())
 		})
 	}
@@ -92,7 +93,7 @@ func TestControllerNameString(t *testing.T) {
 
 func TestStrip(t *testing.T) {
 	str := "a *&b   c "
-	striped := strip(str)
+	striped := clean(str)
 
 	require.Equal(t, striped, "abc")
 }

--- a/pkg/controller/dns/external_dns.go
+++ b/pkg/controller/dns/external_dns.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/Azure/aks-app-routing-operator/pkg/config"
 	"github.com/Azure/aks-app-routing-operator/pkg/controller/common"
+	"github.com/Azure/aks-app-routing-operator/pkg/controller/controllername"
 	"github.com/Azure/aks-app-routing-operator/pkg/manifests"
 	"github.com/Azure/aks-app-routing-operator/pkg/util"
 	appsv1 "k8s.io/api/apps/v1"
@@ -20,7 +21,7 @@ const (
 
 // addExternalDnsReconciler creates a reconciler that manages external dns resources
 func addExternalDnsReconciler(manager ctrl.Manager, resources []client.Object) error {
-	return common.NewResourceReconciler(manager, "externalDnsReconciler", resources, reconcileInterval)
+	return common.NewResourceReconciler(manager, controllername.New("external", "dns", "reconciler"), resources, reconcileInterval)
 }
 
 func addExternalDnsCleaner(manager ctrl.Manager, objs []cleanObj) error {
@@ -45,7 +46,7 @@ func addExternalDnsCleaner(manager ctrl.Manager, objs []cleanObj) error {
 			CompareStrat: common.IgnoreLabels, // ignore labels, we never want to clean namespaces
 		})
 
-	return common.NewCleaner(manager, "externalDnsCleaner", retriever)
+	return common.NewCleaner(manager, controllername.New("external", "dns", "cleaner"), retriever)
 }
 
 // NewExternalDns starts all resources required for external dns

--- a/pkg/controller/ingress/concurrency_watchdog.go
+++ b/pkg/controller/ingress/concurrency_watchdog.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"time"
 
+	"github.com/Azure/aks-app-routing-operator/pkg/controller/controllername"
 	"github.com/go-logr/logr"
 	"github.com/hashicorp/go-multierror"
 	prommodel "github.com/prometheus/client_model/go"
@@ -29,8 +30,8 @@ import (
 	"github.com/Azure/aks-app-routing-operator/pkg/util"
 )
 
-const (
-	concurrencyWatchdogControllerName = "concurrency_watchdog"
+var (
+	concurrencyWatchdogControllerName = controllername.New("concurrency", "watchdog")
 )
 
 // ScrapeFn returns the connection count for the given pod
@@ -109,7 +110,7 @@ func NewConcurrencyWatchdog(manager ctrl.Manager, conf *config.Config, targets [
 		client:     manager.GetClient(),
 		clientset:  clientset,
 		restClient: clientset.CoreV1().RESTClient(),
-		logger:     manager.GetLogger().WithName("ingressWatchdog"),
+		logger:     concurrencyWatchdogControllerName.AddToLogger(manager.GetLogger()),
 		config:     conf,
 		targets:    targets,
 

--- a/pkg/controller/ingress/ingress_class_reconciler.go
+++ b/pkg/controller/ingress/ingress_class_reconciler.go
@@ -2,11 +2,12 @@ package ingress
 
 import (
 	"github.com/Azure/aks-app-routing-operator/pkg/controller/common"
+	"github.com/Azure/aks-app-routing-operator/pkg/controller/controllername"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // NewIngressClassReconciler creates a reconciler that manages ingress class resources
 func NewIngressClassReconciler(manager ctrl.Manager, resources []client.Object, name string) error {
-	return common.NewResourceReconciler(manager, name+"IngressClassReconciler", resources, reconcileInterval)
+	return common.NewResourceReconciler(manager, controllername.New(name, "ingress", "class", "reconciler"), resources, reconcileInterval)
 }

--- a/pkg/controller/ingress/ingress_controller_reconciler.go
+++ b/pkg/controller/ingress/ingress_controller_reconciler.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/Azure/aks-app-routing-operator/pkg/controller/common"
+	"github.com/Azure/aks-app-routing-operator/pkg/controller/controllername"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -15,5 +16,5 @@ const reconcileInterval = time.Minute * 3
 
 // NewIngressControllerReconciler creates a reconciler that manages ingress controller resources
 func NewIngressControllerReconciler(manager ctrl.Manager, resources []client.Object, name string) error {
-	return common.NewResourceReconciler(manager, name+"IngressControllerReconciler", resources, reconcileInterval)
+	return common.NewResourceReconciler(manager, controllername.New(name, "ingress", "controller", "reconciler"), resources, reconcileInterval)
 }

--- a/pkg/controller/keyvault/event_mirror.go
+++ b/pkg/controller/keyvault/event_mirror.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/Azure/aks-app-routing-operator/pkg/controller/controllername"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
@@ -21,8 +22,8 @@ import (
 	"github.com/Azure/aks-app-routing-operator/pkg/util"
 )
 
-const (
-	eventMirrorControllerName = "event_mirror"
+var (
+	eventMirrorControllerName = controllername.New("keyvault", "event", "mirror")
 )
 
 // EventMirror copies events published to pod resources by the Keyvault CSI driver into ingress events.
@@ -65,7 +66,7 @@ func (e *EventMirror) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Res
 	if err != nil {
 		return result, err
 	}
-	logger = logger.WithName("eventMirror")
+	logger = eventMirrorControllerName.AddToLogger(logger)
 
 	event := &corev1.Event{}
 	err = e.client.Get(ctx, req.NamespacedName, event)

--- a/pkg/controller/keyvault/ingress_secret_provider_class.go
+++ b/pkg/controller/keyvault/ingress_secret_provider_class.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/Azure/aks-app-routing-operator/pkg/controller/controllername"
 	"github.com/go-logr/logr"
 	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -24,8 +25,8 @@ import (
 	kvcsi "github.com/Azure/secrets-store-csi-driver-provider-azure/pkg/provider/types"
 )
 
-const (
-	ingressSecretProviderControllerName = "ingress_secret_provider"
+var (
+	ingressSecretProviderControllerName = controllername.New("keyvault", "ingress", "secret", " provider")
 )
 
 // IngressSecretProviderClassReconciler manages a SecretProviderClass for each ingress resource that
@@ -71,7 +72,7 @@ func (i *IngressSecretProviderClassReconciler) Reconcile(ctx context.Context, re
 	if err != nil {
 		return result, err
 	}
-	logger = logger.WithName("secretProviderClassReconciler")
+	logger = ingressSecretProviderControllerName.AddToLogger(logger)
 
 	ing := &netv1.Ingress{}
 	err = i.client.Get(ctx, req.NamespacedName, ing)

--- a/pkg/controller/keyvault/ingress_secret_provider_class_test.go
+++ b/pkg/controller/keyvault/ingress_secret_provider_class_test.go
@@ -6,9 +6,10 @@ package keyvault
 import (
 	"context"
 	"fmt"
-	"github.com/Azure/aks-app-routing-operator/pkg/controller/testutils"
 	"net/url"
 	"testing"
+
+	"github.com/Azure/aks-app-routing-operator/pkg/controller/testutils"
 
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
@@ -167,7 +168,7 @@ func TestIngressSecretProviderClassReconcilerInvalidURL(t *testing.T) {
 
 	// get the before value of the error metrics
 	beforeErrCount := testutils.GetErrMetricCount(t, ingressSecretProviderControllerName)
-	beforeRequestCount := testutils.GetReconcileMetricCount(t, metrics.LabelError, ingressSecretProviderControllerName)
+	beforeRequestCount := testutils.GetReconcileMetricCount(t, ingressSecretProviderControllerName, metrics.LabelError)
 
 	req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: ing.Namespace, Name: ing.Name}}
 	_, err := i.Reconcile(ctx, req)

--- a/pkg/controller/keyvault/placeholder_pod.go
+++ b/pkg/controller/keyvault/placeholder_pod.go
@@ -8,6 +8,7 @@ import (
 	"path"
 	"strconv"
 
+	"github.com/Azure/aks-app-routing-operator/pkg/controller/controllername"
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -24,8 +25,8 @@ import (
 	"github.com/Azure/aks-app-routing-operator/pkg/util"
 )
 
-const (
-	placeholderPodControllerName = "placeholder_pod"
+var (
+	placeholderPodControllerName = controllername.New("keyvault", "placeholder", "pod")
 )
 
 // PlaceholderPodController manages a single-replica deployment of no-op pods that mount the
@@ -67,7 +68,7 @@ func (p *PlaceholderPodController) Reconcile(ctx context.Context, req ctrl.Reque
 	if err != nil {
 		return result, err
 	}
-	logger = logger.WithName("placeholderPodController")
+	logger = placeholderPodControllerName.AddToLogger(logger)
 
 	spc := &secv1.SecretProviderClass{}
 	err = p.client.Get(ctx, req.NamespacedName, spc)

--- a/pkg/controller/metrics/metrics.go
+++ b/pkg/controller/metrics/metrics.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"github.com/Azure/aks-app-routing-operator/pkg/controller/controllername"
 	"github.com/prometheus/client_golang/prometheus"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -32,26 +33,29 @@ func init() {
 
 // HandleControllerReconcileMetrics is meant to be called within a defer for each controller.
 // This lets us put all the metric handling in one place, rather than duplicating it in every controller
-func HandleControllerReconcileMetrics(controllerName string, result ctrl.Result, err error) {
+func HandleControllerReconcileMetrics(controllerName controllername.ControllerNamer, result ctrl.Result, err error) {
+	cn := controllerName.MetricsName()
+
 	switch {
 	// apierrors.IsNotFound is ignored by controllers so this should too
 	case err != nil && !apierrors.IsNotFound(err):
-		AppRoutingReconcileTotal.WithLabelValues(controllerName, LabelError).Inc()
-		AppRoutingReconcileErrors.WithLabelValues(controllerName).Inc()
+		AppRoutingReconcileTotal.WithLabelValues(cn, LabelError).Inc()
+		AppRoutingReconcileErrors.WithLabelValues(cn).Inc()
 	case result.RequeueAfter > 0:
-		AppRoutingReconcileTotal.WithLabelValues(controllerName, LabelRequeueAfter).Inc()
+		AppRoutingReconcileTotal.WithLabelValues(cn, LabelRequeueAfter).Inc()
 	case result.Requeue:
-		AppRoutingReconcileTotal.WithLabelValues(controllerName, LabelRequeue).Inc()
+		AppRoutingReconcileTotal.WithLabelValues(cn, LabelRequeue).Inc()
 	default:
-		AppRoutingReconcileTotal.WithLabelValues(controllerName, LabelSuccess).Inc()
+		AppRoutingReconcileTotal.WithLabelValues(cn, LabelSuccess).Inc()
 	}
 }
 
-func InitControllerMetrics(controllerName string) {
-	AppRoutingReconcileTotal.WithLabelValues(controllerName, LabelError).Add(0)
-	AppRoutingReconcileTotal.WithLabelValues(controllerName, LabelRequeueAfter).Add(0)
-	AppRoutingReconcileTotal.WithLabelValues(controllerName, LabelRequeue).Add(0)
-	AppRoutingReconcileTotal.WithLabelValues(controllerName, LabelSuccess).Add(0)
+func InitControllerMetrics(controllerName controllername.ControllerNamer) {
+	cn := controllerName.MetricsName()
+	AppRoutingReconcileTotal.WithLabelValues(cn, LabelError).Add(0)
+	AppRoutingReconcileTotal.WithLabelValues(cn, LabelRequeueAfter).Add(0)
+	AppRoutingReconcileTotal.WithLabelValues(cn, LabelRequeue).Add(0)
+	AppRoutingReconcileTotal.WithLabelValues(cn, LabelSuccess).Add(0)
 
-	AppRoutingReconcileErrors.WithLabelValues(controllerName).Add(0)
+	AppRoutingReconcileErrors.WithLabelValues(cn).Add(0)
 }

--- a/pkg/controller/osm/ingress_backend_reconciler.go
+++ b/pkg/controller/osm/ingress_backend_reconciler.go
@@ -6,6 +6,7 @@ package osm
 import (
 	"context"
 
+	"github.com/Azure/aks-app-routing-operator/pkg/controller/controllername"
 	"github.com/go-logr/logr"
 	policyv1alpha1 "github.com/openservicemesh/osm/pkg/apis/policy/v1alpha1"
 	netv1 "k8s.io/api/networking/v1"
@@ -18,8 +19,8 @@ import (
 	"github.com/Azure/aks-app-routing-operator/pkg/util"
 )
 
-const (
-	ingressBackendControllerName = "ingress_backend"
+var (
+	ingressBackendControllerName = controllername.New("osm", "ingress", "backend")
 )
 
 // IngressControllerNamer returns the controller name that an Ingress consumes and a boolean indicating whether it's managed by web app routing.
@@ -91,7 +92,7 @@ func (i *IngressBackendReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	if err != nil {
 		return result, err
 	}
-	logger = logger.WithName("ingressBackendReconciler")
+	logger = ingressBackendControllerName.AddToLogger(logger)
 
 	ing := &netv1.Ingress{}
 	err = i.client.Get(ctx, req.NamespacedName, ing)

--- a/pkg/controller/osm/ingress_cert_config_reconciler.go
+++ b/pkg/controller/osm/ingress_cert_config_reconciler.go
@@ -6,6 +6,7 @@ package osm
 import (
 	"context"
 
+	"github.com/Azure/aks-app-routing-operator/pkg/controller/controllername"
 	"github.com/go-logr/logr"
 	cfgv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -16,12 +17,15 @@ import (
 )
 
 const (
-	osmNamespace                    = "kube-system"
-	osmMeshConfigName               = "osm-mesh-config"
-	osmNginxSAN                     = "ingress-nginx.ingress.cluster.local"
-	osmClientCertValidity           = "24h"
-	osmClientCertName               = "osm-ingress-client-cert"
-	ingressCertConfigControllerName = "ingress_cert_config"
+	osmNamespace          = "kube-system"
+	osmMeshConfigName     = "osm-mesh-config"
+	osmNginxSAN           = "ingress-nginx.ingress.cluster.local"
+	osmClientCertValidity = "24h"
+	osmClientCertName     = "osm-ingress-client-cert"
+)
+
+var (
+	ingressCertConfigControllerName = controllername.New("osm", "ingress", "cert", "config")
 )
 
 // IngressCertConfigReconciler updates the Open Service Mesh configuration to generate a client cert
@@ -58,7 +62,7 @@ func (i *IngressCertConfigReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	if err != nil {
 		return result, err
 	}
-	logger = logger.WithName("ingressCertConfigReconciler")
+	logger = ingressCertConfigControllerName.AddToLogger(logger)
 
 	if req.Name != osmMeshConfigName || req.Namespace != osmNamespace {
 		return result, nil

--- a/pkg/controller/service/ingress_reconciler.go
+++ b/pkg/controller/service/ingress_reconciler.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/Azure/aks-app-routing-operator/pkg/controller/controllername"
 	"github.com/Azure/aks-app-routing-operator/pkg/manifests"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -20,8 +21,8 @@ import (
 	"github.com/Azure/aks-app-routing-operator/pkg/util"
 )
 
-const (
-	ingressControllerName = "ingress"
+var (
+	ingressControllerName = controllername.New("service", "ingress", "reconciler")
 )
 
 // NginxIngressReconciler manages an opinionated ingress resource for services that define certain annotations.
@@ -67,7 +68,7 @@ func (i *NginxIngressReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	if err != nil {
 		return result, err
 	}
-	logger = logger.WithName("ingressReconciler")
+	logger = ingressControllerName.AddToLogger(logger)
 
 	svc := &corev1.Service{}
 	err = i.client.Get(ctx, req.NamespacedName, svc)

--- a/pkg/controller/testutils/testutils.go
+++ b/pkg/controller/testutils/testutils.go
@@ -3,6 +3,7 @@ package testutils
 import (
 	"testing"
 
+	"github.com/Azure/aks-app-routing-operator/pkg/controller/controllername"
 	"github.com/Azure/aks-app-routing-operator/pkg/controller/metrics"
 	promDTO "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/require"
@@ -10,8 +11,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 )
 
-func GetErrMetricCount(t *testing.T, controllerName string) float64 {
-	errMetric, err := metrics.AppRoutingReconcileErrors.GetMetricWithLabelValues(controllerName)
+func GetErrMetricCount(t *testing.T, controllerName controllername.ControllerNamer) float64 {
+	errMetric, err := metrics.AppRoutingReconcileErrors.GetMetricWithLabelValues(controllerName.MetricsName())
 	require.NoError(t, err)
 
 	metricProto := &promDTO.Metric{}
@@ -23,8 +24,8 @@ func GetErrMetricCount(t *testing.T, controllerName string) float64 {
 	return beforeCount
 }
 
-func GetReconcileMetricCount(t *testing.T, controllerName, label string) float64 {
-	errMetric, err := metrics.AppRoutingReconcileTotal.GetMetricWithLabelValues(controllerName, label)
+func GetReconcileMetricCount(t *testing.T, controllerName controllername.ControllerNamer, label string) float64 {
+	errMetric, err := metrics.AppRoutingReconcileTotal.GetMetricWithLabelValues(controllerName.MetricsName(), label)
 	require.NoError(t, err)
 
 	metricProto := &promDTO.Metric{}


### PR DESCRIPTION
# Description

Adds controller name interface to all controllers. Allows for us to enforce consistent logging and metric naming for all controllers. Will be useful for alerting based on prometheus especially. If an alert fires we can attach an automatically generated query that can search relevant controller logs for that alert.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Unit and e2e tested

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
