### PR TITLE
remove resource limit on nginx ingress controller

### DIFF
--- a/pkg/manifests/nginx.go
+++ b/pkg/manifests/nginx.go
@@ -445,10 +445,12 @@ func newNginxIngressControllerDeployment(conf *config.Config, ingressConfig *Ngi
 								corev1.ResourceCPU:    resource.MustParse("500m"),
 								corev1.ResourceMemory: resource.MustParse("127Mi"),
 							},
-							Limits: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("1500m"),
-								corev1.ResourceMemory: resource.MustParse("512Mi"),
-							},
+							// It's not a recommended practice to specify limits for Nginx Ingress Controller.
+							// NGINX automatically claims workers based on the number of available CPUs meaning
+							// it's impossible to have a single number that fits all potential customer environments.
+							// It's fine for this to be a Burstable container since we have multiple replicas and PDB
+							// ensuring that some pods are always available.
+							// https://github.com/kubernetes/ingress-nginx/blob/4bac1200bfe4c95f654ffb86bea18ce9fc1c8630/charts/ingress-nginx/values.yaml#L342
 						},
 					}))},
 				}),
@@ -515,7 +517,7 @@ func newNginxIngressControllerHPA(conf *config.Config, ingressConfig *NginxIngre
 			},
 			MinReplicas:                    util.Int32Ptr(2),
 			MaxReplicas:                    100,
-			TargetCPUUtilizationPercentage: util.Int32Ptr(90),
+			TargetCPUUtilizationPercentage: util.Int32Ptr(80),
 		},
 	}
 }


### PR DESCRIPTION
# Description

Removes the resource limit on the nginx ingress controller. This allows for app routing to work on clusters with many cpus. NGINX automatically scales worker processes based on node cpus.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested on e2e and locally.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
