### PR TITLE
add retry to build acr image e2e

### DIFF
--- a/testing/e2e/clients/acr.go
+++ b/testing/e2e/clients/acr.go
@@ -78,8 +78,6 @@ func NewAcr(ctx context.Context, subscriptionId, resourceGroup, name, location s
 		return nil, fmt.Errorf("name is nil")
 	}
 
-	time.Sleep(20 * time.Second)
-
 	return &acr{
 		id:             *result.ID,
 		name:           *result.Name,

--- a/testing/e2e/clients/acr.go
+++ b/testing/e2e/clients/acr.go
@@ -106,7 +106,7 @@ func (a *acr) BuildAndPush(ctx context.Context, imageName, dockerfilePath string
 		// Ideally, we'd use the sdk to build and push the image but I couldn't get it working.
 		// I matched everything on the az cli but wasn't able to get it working with the sdk.
 		// https://github.com/Azure/azure-cli/blob/5f9a8fa25cc1c980ebe5e034bd419c95a1c578e2/src/azure-cli/azure/cli/command_modules/acr/build.py#L25
-		cmd := exec.Command("az", "acr", "build", "--registry", a.name, "--image", imageName, "--subscription", a.subscriptionId, dockerfilePath)
+		cmd := exec.Command("az", "acr", "build", "--registry", a.name, "--image", imageName, "--subscription", a.subscriptionId, "--resource-group", a.resourceGroup, dockerfilePath)
 		cmd.Stdout = newLogWriter(lgr, "building and pushing acr image: ", nil)
 		var errLog bytes.Buffer
 		cmd.Stderr = io.MultiWriter(&errLog, newLogWriter(lgr, "building and pushing acr image: ", to.Ptr(slog.LevelError)))

--- a/testing/e2e/clients/acr.go
+++ b/testing/e2e/clients/acr.go
@@ -107,10 +107,8 @@ func (a *acr) BuildAndPush(ctx context.Context, imageName, dockerfilePath string
 		// https://github.com/Azure/azure-cli/blob/5f9a8fa25cc1c980ebe5e034bd419c95a1c578e2/src/azure-cli/azure/cli/command_modules/acr/build.py#L25
 		cmd := exec.Command("az", "acr", "build", "--registry", a.name, "--image", imageName, "--subscription", a.subscriptionId, dockerfilePath)
 		cmd.Stdout = newLogWriter(lgr, "building and pushing acr image: ", nil)
-
 		var errLog bytes.Buffer
-		stdErr := io.MultiWriter(&errLog, newLogWriter(lgr, "building and pushing acr image: ", to.Ptr(slog.LevelError)))
-		cmd.Stderr = stdErr
+		cmd.Stderr = io.MultiWriter(&errLog, newLogWriter(lgr, "building and pushing acr image: ", to.Ptr(slog.LevelError)))
 		err := cmd.Run()
 		if err == nil {
 			break

--- a/testing/e2e/clients/acr.go
+++ b/testing/e2e/clients/acr.go
@@ -95,7 +95,9 @@ func (a *acr) BuildAndPush(ctx context.Context, imageName, dockerfilePath string
 	// Ideally, we'd use the sdk to build and push the image but I couldn't get it working.
 	// I matched everything on the az cli but wasn't able to get it working with the sdk.
 	// https://github.com/Azure/azure-cli/blob/5f9a8fa25cc1c980ebe5e034bd419c95a1c578e2/src/azure-cli/azure/cli/command_modules/acr/build.py#L25
-	cmd := exec.Command("az", "acr", "build", "--registry", a.name, "--image", imageName, "--subscription", a.subscriptionId, dockerfilePath)
+	// ~~~~
+	// Without the resource group flag the command often fails with unable to find the acr in the subscription. We are unsure why since this isn't a required flag
+	cmd := exec.Command("az", "acr", "build", "--registry", a.name, "--image", imageName, "--subscription", a.subscriptionId, "--resource-group", a.resourceGroup, dockerfilePath)
 	cmd.Stdout = newLogWriter(lgr, "building and pushing acr image: ", nil)
 	cmd.Stderr = newLogWriter(lgr, "building and pushing acr image: ", to.Ptr(slog.LevelError))
 	if err := cmd.Run(); err != nil {

--- a/testing/e2e/clients/acr.go
+++ b/testing/e2e/clients/acr.go
@@ -121,9 +121,9 @@ func (a *acr) BuildAndPush(ctx context.Context, imageName, dockerfilePath string
 			// We've tried alternate strategies like polling the sdk to see if the acr exists but that
 			// tells us it exists then the acr command fails. This is the only reliable way we've found
 			// to wait for the acr to be ready.
-			lgr.Info("failed to build and push acr image", "error", err, "stderr", errLog.String())
 			if !cantFindAcrRegex.Match(errLog.Bytes()) {
-				return fmt.Errorf("starting build and push command: %w", err)
+				lgr.Error("failed to build and push acr image")
+				return fmt.Errorf("running build and push command: %w", err)
 			}
 
 			if time.Since(start) > 1*time.Minute {

--- a/testing/e2e/clients/acr.go
+++ b/testing/e2e/clients/acr.go
@@ -117,7 +117,11 @@ func (a *acr) BuildAndPush(ctx context.Context, imageName, dockerfilePath string
 		if err == nil {
 			break
 		} else {
-			if !cantFindAcrRegex.Match(buf.Bytes()) { // if this regex matches the az cli can't find the acr, things just need more time to propagate
+			// if this regex matches the az cli can't find the acr, things just need more time to propagate.
+			// We've tried alternate strategies like polling the sdk to see if the acr exists but that
+			// tells us it exists then the acr command fails. This is the only reliable way we've found
+			// to wait for the acr to be ready.
+			if !cantFindAcrRegex.Match(buf.Bytes()) {
 				return fmt.Errorf("starting build and push command: %w", err)
 			}
 


### PR DESCRIPTION
# Description

Adds a retry on acr image build in e2e. This fixes a random error that started appearing yesterday where e2e occasionally says it can't find the acr in the subscription on an acr build.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Local e2e

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
