### PR TITLE
remove limits and add topology spread

### DIFF
--- a/pkg/manifests/fixtures/nginx/full.json
+++ b/pkg/manifests/fixtures/nginx/full.json
@@ -554,10 +554,6 @@
                   }
                 ],
                 "resources": {
-                  "limits": {
-                    "cpu": "1500m",
-                    "memory": "512Mi"
-                  },
                   "requests": {
                     "cpu": "500m",
                     "memory": "127Mi"
@@ -633,7 +629,19 @@
                 "operator": "Exists"
               }
             ],
-            "priorityClassName": "system-node-critical"
+            "priorityClassName": "system-node-critical",
+            "topologySpreadConstraints": [
+              {
+                "maxSkew": 1,
+                "topologyKey": "kubernetes.io/hostname",
+                "whenUnsatisfiable": "ScheduleAnyway",
+                "labelSelector": {
+                  "matchLabels": {
+                    "app": "nginx"
+                  }
+                }
+              }
+            ]
           }
         },
         "strategy": {},
@@ -732,7 +740,7 @@
         },
         "minReplicas": 2,
         "maxReplicas": 100,
-        "targetCPUUtilizationPercentage": 90
+        "targetCPUUtilizationPercentage": 80
       },
       "status": {
         "currentReplicas": 0,

--- a/pkg/manifests/fixtures/nginx/internal.json
+++ b/pkg/manifests/fixtures/nginx/internal.json
@@ -554,10 +554,6 @@
                   }
                 ],
                 "resources": {
-                  "limits": {
-                    "cpu": "1500m",
-                    "memory": "512Mi"
-                  },
                   "requests": {
                     "cpu": "500m",
                     "memory": "127Mi"
@@ -633,7 +629,19 @@
                 "operator": "Exists"
               }
             ],
-            "priorityClassName": "system-node-critical"
+            "priorityClassName": "system-node-critical",
+            "topologySpreadConstraints": [
+              {
+                "maxSkew": 1,
+                "topologyKey": "kubernetes.io/hostname",
+                "whenUnsatisfiable": "ScheduleAnyway",
+                "labelSelector": {
+                  "matchLabels": {
+                    "app": "nginx"
+                  }
+                }
+              }
+            ]
           }
         },
         "strategy": {},
@@ -732,7 +740,7 @@
         },
         "minReplicas": 2,
         "maxReplicas": 100,
-        "targetCPUUtilizationPercentage": 90
+        "targetCPUUtilizationPercentage": 80
       },
       "status": {
         "currentReplicas": 0,

--- a/pkg/manifests/fixtures/nginx/kube-system.json
+++ b/pkg/manifests/fixtures/nginx/kube-system.json
@@ -476,10 +476,6 @@
                   }
                 ],
                 "resources": {
-                  "limits": {
-                    "cpu": "1500m",
-                    "memory": "512Mi"
-                  },
                   "requests": {
                     "cpu": "500m",
                     "memory": "127Mi"
@@ -555,7 +551,19 @@
                 "operator": "Exists"
               }
             ],
-            "priorityClassName": "system-node-critical"
+            "priorityClassName": "system-node-critical",
+            "topologySpreadConstraints": [
+              {
+                "maxSkew": 1,
+                "topologyKey": "kubernetes.io/hostname",
+                "whenUnsatisfiable": "ScheduleAnyway",
+                "labelSelector": {
+                  "matchLabels": {
+                    "app": "nginx"
+                  }
+                }
+              }
+            ]
           }
         },
         "strategy": {},
@@ -630,7 +638,7 @@
         },
         "minReplicas": 2,
         "maxReplicas": 100,
-        "targetCPUUtilizationPercentage": 90
+        "targetCPUUtilizationPercentage": 80
       },
       "status": {
         "currentReplicas": 0,

--- a/pkg/manifests/fixtures/nginx/no-ownership.json
+++ b/pkg/manifests/fixtures/nginx/no-ownership.json
@@ -490,10 +490,6 @@
                   }
                 ],
                 "resources": {
-                  "limits": {
-                    "cpu": "1500m",
-                    "memory": "512Mi"
-                  },
                   "requests": {
                     "cpu": "500m",
                     "memory": "127Mi"
@@ -569,7 +565,19 @@
                 "operator": "Exists"
               }
             ],
-            "priorityClassName": "system-node-critical"
+            "priorityClassName": "system-node-critical",
+            "topologySpreadConstraints": [
+              {
+                "maxSkew": 1,
+                "topologyKey": "kubernetes.io/hostname",
+                "whenUnsatisfiable": "ScheduleAnyway",
+                "labelSelector": {
+                  "matchLabels": {
+                    "app": "nginx"
+                  }
+                }
+              }
+            ]
           }
         },
         "strategy": {},
@@ -644,7 +652,7 @@
         },
         "minReplicas": 2,
         "maxReplicas": 100,
-        "targetCPUUtilizationPercentage": 90
+        "targetCPUUtilizationPercentage": 80
       },
       "status": {
         "currentReplicas": 0,

--- a/pkg/manifests/fixtures/nginx/optional-features-disabled.json
+++ b/pkg/manifests/fixtures/nginx/optional-features-disabled.json
@@ -489,10 +489,6 @@
                   }
                 ],
                 "resources": {
-                  "limits": {
-                    "cpu": "1500m",
-                    "memory": "512Mi"
-                  },
                   "requests": {
                     "cpu": "500m",
                     "memory": "127Mi"
@@ -568,7 +564,19 @@
                 "operator": "Exists"
               }
             ],
-            "priorityClassName": "system-node-critical"
+            "priorityClassName": "system-node-critical",
+            "topologySpreadConstraints": [
+              {
+                "maxSkew": 1,
+                "topologyKey": "kubernetes.io/hostname",
+                "whenUnsatisfiable": "ScheduleAnyway",
+                "labelSelector": {
+                  "matchLabels": {
+                    "app": "nginx"
+                  }
+                }
+              }
+            ]
           }
         },
         "strategy": {},
@@ -643,7 +651,7 @@
         },
         "minReplicas": 2,
         "maxReplicas": 100,
-        "targetCPUUtilizationPercentage": 90
+        "targetCPUUtilizationPercentage": 80
       },
       "status": {
         "currentReplicas": 0,


### PR DESCRIPTION
# Description

Removes the resource limit on the nginx ingress controller. This allows for app routing to work on clusters with many cpus. NGINX automatically scales worker processes based on node cpus.

We also change the HPA to scale slightly more aggressively. This should lower the amount of CPU used by a single nginx ingress controller replica which means that the actual usage should be more in-line with the Resource Requests (which is good because it's guaranteed).

Pod topology spread ensures nginx ingress controller scheduled on different nodes when possible. Helps avoid single Node failure taking down the Ingress.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

e2e and unit

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
