### PR TITLE
always reconcile default nic

### DIFF
--- a/pkg/controller/nginxingress/default_test.go
+++ b/pkg/controller/nginxingress/default_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/require"
 	netv1 "k8s.io/api/networking/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -22,61 +21,32 @@ func TestDefaultNicReconciler(t *testing.T) {
 	require.NoError(t, netv1.AddToScheme(scheme))
 	cl := fake.NewClientBuilder().WithScheme(scheme).Build()
 
-	// when default nic doesn't exist in cluster we don't create the default nic
+	// prove we always create the default nic
 	d := &defaultNicReconciler{
 		client: cl,
 		lgr:    logr.Discard(),
 		name:   controllername.New("testing"),
 	}
 
-	require.NoError(t, d.tick(context.Background()))
-
 	nic := &approutingv1alpha1.NginxIngressController{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: DefaultNicName,
 		},
 	}
-	require.True(t, k8serrors.IsNotFound(d.client.Get(context.Background(), types.NamespacedName{Name: nic.Name}, nic)))
-
-	// when default nic exists in cluster we create the default nic
-	require.NoError(t, cl.Create(context.Background(), &netv1.IngressClass{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: DefaultIcName,
-		},
-	}))
 	require.NoError(t, d.tick(context.Background()))
 	require.NoError(t, d.client.Get(context.Background(), types.NamespacedName{Name: nic.Name}, nic))
 	require.Equal(t, "nginx", nic.Spec.ControllerNamePrefix)
 	require.Equal(t, DefaultIcName, nic.Spec.IngressClassName)
 
-}
-
-func TestShouldCreateDefaultNic(t *testing.T) {
-	scheme := runtime.NewScheme()
-	require.NoError(t, approutingv1alpha1.AddToScheme(scheme))
-	require.NoError(t, netv1.AddToScheme(scheme))
-	cl := fake.NewClientBuilder().WithScheme(scheme).Build()
-
-	// when default ic doesn't exist in cluster
-	shouldCreate, err := shouldCreateDefaultNic(cl)
-	require.NoError(t, err)
-	require.False(t, shouldCreate)
-
-	// when default ic exists in cluster
-	require.NoError(t, cl.Create(context.Background(), &netv1.IngressClass{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: DefaultIcName,
-		},
-	}))
-	shouldCreate, err = shouldCreateDefaultNic(cl)
-	require.NoError(t, err)
-	require.True(t, shouldCreate)
-
-	defaultNic := GetDefaultNginxIngressController()
-	require.NoError(t, cl.Create(context.Background(), &defaultNic))
-	shouldCreate, err = shouldCreateDefaultNic(cl)
-	require.NoError(t, err)
-	require.False(t, shouldCreate)
+	// prove there are no default nic lb service annotations
+	require.Equal(t, *new(map[string]string), nic.Spec.LoadBalancerAnnotations, "default nic service annotations should be empty initially")
+	// prove we don't overwrite the default nic lb service annotations
+	newLbAnnotations := map[string]string{"foo": "bar"}
+	nic.Spec.LoadBalancerAnnotations = newLbAnnotations
+	require.NoError(t, d.client.Update(context.Background(), nic))
+	require.NoError(t, d.tick(context.Background()))
+	require.NoError(t, d.client.Get(context.Background(), types.NamespacedName{Name: nic.Name}, nic))
+	require.Equal(t, newLbAnnotations, nic.Spec.LoadBalancerAnnotations, "default nic service annotations should not be overwritten")
 }
 
 func TestGetDefaultIngressClassControllerClass(t *testing.T) {


### PR DESCRIPTION
# Description

Switches operator logic to always create / ensure the default nic exists. The previous model only ensured the default nic when a user was previously using app routing (the upgrade scenario).

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Unit tested and tested locally.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
