### PR TITLE
add log for number of target nginx replicas

### DIFF
--- a/pkg/controller/nginxingress/nginx_ingress_controller.go
+++ b/pkg/controller/nginxingress/nginx_ingress_controller.go
@@ -155,7 +155,7 @@ func (n *nginxIngressControllerReconciler) Reconcile(ctx context.Context, req ct
 		return ctrl.Result{}, fmt.Errorf("reconciling resource: %w", err)
 	}
 	if replicas := resources.Deployment.Spec.Replicas; replicas != nil {
-		lgr.Info(fmt.Sprintf("nginx deployment targets %s replicas", *replicas), "replicas", *replicas)
+		lgr.Info(fmt.Sprintf("nginx deployment targets %d replicas", *replicas), "replicas", *replicas)
 	}
 
 	return ctrl.Result{}, nil

--- a/pkg/controller/nginxingress/nginx_ingress_controller.go
+++ b/pkg/controller/nginxingress/nginx_ingress_controller.go
@@ -154,7 +154,9 @@ func (n *nginxIngressControllerReconciler) Reconcile(ctx context.Context, req ct
 		lgr.Error(err, "unable to reconcile resource")
 		return ctrl.Result{}, fmt.Errorf("reconciling resource: %w", err)
 	}
-	lgr.Info(fmt.Sprintf("nginx deployment targets %s replicas", resources.Deployment.Spec.Replicas), "replicas", resources.Deployment.Spec.Replicas)
+	if replicas := resources.Deployment.Spec.Replicas; replicas != nil {
+		lgr.Info(fmt.Sprintf("nginx deployment targets %s replicas", *replicas), "replicas", *replicas)
+	}
 
 	return ctrl.Result{}, nil
 }

--- a/pkg/controller/nginxingress/nginx_ingress_controller.go
+++ b/pkg/controller/nginxingress/nginx_ingress_controller.go
@@ -154,6 +154,7 @@ func (n *nginxIngressControllerReconciler) Reconcile(ctx context.Context, req ct
 		lgr.Error(err, "unable to reconcile resource")
 		return ctrl.Result{}, fmt.Errorf("reconciling resource: %w", err)
 	}
+	lgr.Info("nginx deployment targets %s replicas", resources.Deployment.Spec.Replicas, "replicas", resources.Deployment.Spec.Replicas)
 
 	return ctrl.Result{}, nil
 }

--- a/pkg/controller/nginxingress/nginx_ingress_controller.go
+++ b/pkg/controller/nginxingress/nginx_ingress_controller.go
@@ -154,7 +154,7 @@ func (n *nginxIngressControllerReconciler) Reconcile(ctx context.Context, req ct
 		lgr.Error(err, "unable to reconcile resource")
 		return ctrl.Result{}, fmt.Errorf("reconciling resource: %w", err)
 	}
-	lgr.Info("nginx deployment targets %s replicas", resources.Deployment.Spec.Replicas, "replicas", resources.Deployment.Spec.Replicas)
+	lgr.Info(fmt.Sprintf("nginx deployment targets %s replicas", resources.Deployment.Spec.Replicas), "replicas", resources.Deployment.Spec.Replicas)
 
 	return ctrl.Result{}, nil
 }


### PR DESCRIPTION
# Description

Adds a log printing the number of desired nginx replicas. Useful for informing us if customer manually changes the number of replicas to 0 and records what the HPA is doing.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Locally

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
