### PR TITLE
set download artifact version to v3

### DIFF
--- a/.github/workflows/e2ev2-provision-test.yaml
+++ b/.github/workflows/e2ev2-provision-test.yaml
@@ -74,7 +74,7 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - uses: actions/download-artifact@master
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: infra
           path: testing/e2e/


### PR DESCRIPTION
# Description

Need to set download artifact version to v3 to match the upload artifact version. Can't use v4 because they switched the scope. https://github.blog/changelog/2023-12-14-github-actions-artifacts-v4-is-now-generally-available/

We should pin to sha anyways. Not sure why this was ever set to `main`. Security best practice is to use the sha.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Workflows

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
