### PR TITLE
inherit immutable fields in placeholder pod reconciler

### DIFF
--- a/pkg/controller/keyvault/placeholder_pod.go
+++ b/pkg/controller/keyvault/placeholder_pod.go
@@ -143,13 +143,13 @@ func (p *PlaceholderPodController) Reconcile(ctx context.Context, req ctrl.Reque
 	logger.Info("reconciling placeholder deployment for secret provider class")
 	if err = p.buildDeployment(ctx, dep, spc, ing); err != nil {
 		err = fmt.Errorf("building deployment: %w", err)
-		p.events.Eventf(ing, "Warning", "FailedUpdateOrCreatePlaceholderPodDeployment", "error while building placeholder pod Deployment needed to pull Keyvault reference: %v", err)
+		p.events.Eventf(ing, "Warning", "FailedUpdateOrCreatePlaceholderPodDeployment", "error while building placeholder pod Deployment needed to pull Keyvault reference: %s", err.Error())
 		logger.Error(err, "failed to build placeholder deployment")
 		return result, err
 	}
 
 	if err = util.Upsert(ctx, p.client, dep); err != nil {
-		p.events.Eventf(ing, "Warning", "FailedUpdateOrCreatePlaceholderPodDeployment", "error while creating or updating placeholder pod Deployment needed to pull Keyvault reference: %v", err)
+		p.events.Eventf(ing, "Warning", "FailedUpdateOrCreatePlaceholderPodDeployment", "error while creating or updating placeholder pod Deployment needed to pull Keyvault reference: %s", err.Error())
 		return result, err
 	}
 

--- a/pkg/controller/keyvault/placeholder_pod.go
+++ b/pkg/controller/keyvault/placeholder_pod.go
@@ -15,6 +15,7 @@ import (
 	netv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -140,7 +141,13 @@ func (p *PlaceholderPodController) Reconcile(ctx context.Context, req ctrl.Reque
 	}
 	// Manage a deployment resource
 	logger.Info("reconciling placeholder deployment for secret provider class")
-	p.buildDeployment(dep, spc, ing)
+	if err = p.buildDeployment(ctx, dep, spc, ing); err != nil {
+		err = fmt.Errorf("building deployment: %w", err)
+		p.events.Eventf(ing, "Warning", "FailedUpdateOrCreatePlaceholderPodDeployment", "error while building placeholder pod Deployment needed to pull Keyvault reference: %v", err)
+		logger.Error(err, "failed to build placeholder deployment")
+		return result, err
+	}
+
 	if err = util.Upsert(ctx, p.client, dep); err != nil {
 		p.events.Eventf(ing, "Warning", "FailedUpdateOrCreatePlaceholderPodDeployment", "error while creating or updating placeholder pod Deployment needed to pull Keyvault reference: %v", err)
 		return result, err
@@ -149,8 +156,29 @@ func (p *PlaceholderPodController) Reconcile(ctx context.Context, req ctrl.Reque
 	return result, nil
 }
 
-func (p *PlaceholderPodController) buildDeployment(dep *appsv1.Deployment, spc *secv1.SecretProviderClass, ing *netv1.Ingress) {
+// getCurrentDeployment returns the current deployment for the given name or nil if it does not exist. nil, nil is returned if the deployment is not found
+func (p *PlaceholderPodController) getCurrentDeployment(ctx context.Context, name types.NamespacedName) (*appsv1.Deployment, error) {
+	dep := &appsv1.Deployment{}
+	err := p.client.Get(ctx, name, dep)
+	if err != nil {
+		return nil, client.IgnoreNotFound(err)
+	}
+
+	return dep, nil
+}
+
+func (p *PlaceholderPodController) buildDeployment(ctx context.Context, dep *appsv1.Deployment, spc *secv1.SecretProviderClass, ing *netv1.Ingress) error {
+	old, err := p.getCurrentDeployment(ctx, client.ObjectKeyFromObject(dep))
+	if err != nil {
+		return fmt.Errorf("getting current deployment: %w", err)
+	}
+
 	labels := map[string]string{"app": spc.Name}
+
+	if old != nil { // we need to ensure that immutable fields are not changed
+		labels = old.Spec.Selector.MatchLabels
+	}
+
 	dep.Spec = appsv1.DeploymentSpec{
 		Replicas:             util.Int32Ptr(1),
 		RevisionHistoryLimit: util.Int32Ptr(2),
@@ -195,4 +223,5 @@ func (p *PlaceholderPodController) buildDeployment(dep *appsv1.Deployment, spc *
 			}),
 		},
 	}
+	return nil
 }

--- a/pkg/controller/keyvault/placeholder_pod_test.go
+++ b/pkg/controller/keyvault/placeholder_pod_test.go
@@ -358,3 +358,24 @@ func TestNewPlaceholderPodController(t *testing.T) {
 	err = NewPlaceholderPodController(m, conf, ingressManager)
 	require.NoError(t, err)
 }
+
+func TestGetCurrentDeployment(t *testing.T) {
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-deployment",
+			Namespace: "test-namespace",
+		},
+	}
+	c := fake.NewFakeClient(dep)
+	p := &PlaceholderPodController{client: c}
+
+	// can find existing deployment
+	dep, err := p.getCurrentDeployment(context.Background(), client.ObjectKeyFromObject(dep))
+	require.NoError(t, err)
+	require.NotNil(t, dep)
+
+	// returns nil if deployment does not exist
+	dep, err = p.getCurrentDeployment(context.Background(), client.ObjectKey{Name: "does-not-exist", Namespace: "test-namespace"})
+	require.NoError(t, err)
+	require.Nil(t, dep)
+}

--- a/pkg/controller/keyvault/placeholder_pod_test.go
+++ b/pkg/controller/keyvault/placeholder_pod_test.go
@@ -331,7 +331,6 @@ func TestPlaceholderPodControllerNoManagedByLabels(t *testing.T) {
 
 	// Prove the deployment was not deleted
 	require.False(t, errors.IsNotFound(c.Get(ctx, client.ObjectKeyFromObject(dep), dep)))
-
 }
 
 func TestNewPlaceholderPodController(t *testing.T) {

--- a/pkg/controller/keyvault/placeholder_pod_test.go
+++ b/pkg/controller/keyvault/placeholder_pod_test.go
@@ -114,7 +114,7 @@ func TestPlaceholderPodControllerIntegration(t *testing.T) {
 		Selector:             &metav1.LabelSelector{MatchLabels: expectedLabels},
 		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
-				Labels: expectedLabels,
+				Labels: util.MergeMaps(expectedLabels),
 				Annotations: map[string]string{
 					"kubernetes.azure.com/observed-generation": "123",
 					"kubernetes.azure.com/purpose":             "hold CSI mount to enable keyvault-to-k8s secret mirroring",
@@ -314,6 +314,7 @@ func TestPlaceholderPodControllerNoManagedByLabels(t *testing.T) {
 
 	// Prove the deployment was not deleted
 	require.False(t, errors.IsNotFound(c.Get(ctx, client.ObjectKeyFromObject(dep), dep)))
+
 }
 
 func TestNewPlaceholderPodController(t *testing.T) {


### PR DESCRIPTION
# Description

Makes the placeholder pod reconciler compatible with immutable fields by inheriting the immutable fields into the reconciled manifests.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

E2e and unit tested

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
