### PR TITLE
Corrected dates from 2023 to 2024

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.1] - 2023-01-23
+## [0.2.1] - 2024-01-23
 
 ### Fixed
 
 - Respect immutable fields in Placeholder Pod reconciler - [#153](https://github.com/Azure/aks-app-routing-operator/pull/153)
 
-## [0.2.0] - 2023-01-11
+## [0.2.0] - 2024-01-11
 
 ### Changes
 


### PR DESCRIPTION
# Description

This pull request includes minor changes to the `CHANGELOG.md` file. The changes update the dates for the 0.2.1 and 0.2.0 versions of the project.

Changes to version dates:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL8-R14): Updated the dates for versions 0.2.1 and 0.2.0 from 2023 to 2024.
