### PR TITLE
Temporary Changes for Scale Tests

### DIFF
--- a/pkg/manifests/common.go
+++ b/pkg/manifests/common.go
@@ -66,10 +66,6 @@ func Namespace(conf *config.Config) *corev1.Namespace {
 		},
 	}
 
-	if !conf.DisableOSM {
-		ns.ObjectMeta.Annotations["openservicemesh.io/sidecar-injection"] = "disabled"
-	}
-
 	return ns
 }
 

--- a/pkg/manifests/common.go
+++ b/pkg/manifests/common.go
@@ -62,8 +62,12 @@ func Namespace(conf *config.Config) *corev1.Namespace {
 			Name: conf.NS,
 			// don't set top-level labels,namespace is not managed by operator
 			Labels:      map[string]string{},
-			Annotations: map[string]string{"openservicemesh.io/sidecar-injection": "disabled"},
+			Annotations: map[string]string{},
 		},
+	}
+
+	if !conf.DisableOSM {
+		ns.ObjectMeta.Annotations["openservicemesh.io/sidecar-injection"] = "disabled"
 	}
 
 	return ns

--- a/pkg/manifests/common.go
+++ b/pkg/manifests/common.go
@@ -62,7 +62,7 @@ func Namespace(conf *config.Config) *corev1.Namespace {
 			Name: conf.NS,
 			// don't set top-level labels,namespace is not managed by operator
 			Labels:      map[string]string{},
-			Annotations: map[string]string{},
+			Annotations: map[string]string{"openservicemesh.io/sidecar-injection": "disabled"},
 		},
 	}
 

--- a/pkg/manifests/nginx.go
+++ b/pkg/manifests/nginx.go
@@ -417,6 +417,9 @@ func newNginxIngressControllerDeployment(conf *config.Config, ingressConfig *Ngi
 	}
 
 	podAnnotations := map[string]string{}
+	if !conf.DisableOSM {
+		podAnnotations["openservicemesh.io/sidecar-injection"] = "enabled"
+	}
 
 	for k, v := range promAnnotations {
 		podAnnotations[k] = v

--- a/pkg/manifests/nginx.go
+++ b/pkg/manifests/nginx.go
@@ -560,7 +560,7 @@ func newNginxIngressControllerHPA(conf *config.Config, ingressConfig *NginxIngre
 				Name:       ingressConfig.ResourceName,
 			},
 			MinReplicas:                    util.Int32Ptr(2),
-			MaxReplicas:                    500,
+			MaxReplicas:                    100,
 			TargetCPUUtilizationPercentage: util.Int32Ptr(70),
 		},
 	}

--- a/pkg/manifests/nginx.go
+++ b/pkg/manifests/nginx.go
@@ -418,7 +418,7 @@ func newNginxIngressControllerDeployment(conf *config.Config, ingressConfig *Ngi
 
 	podAnnotations := map[string]string{}
 	if !conf.DisableOSM {
-		podAnnotations["openservicemesh.io/sidecar-injection"] = "disabled"
+		//podAnnotations["openservicemesh.io/sidecar-injection"] = "disabled"
 	}
 
 	for k, v := range promAnnotations {

--- a/pkg/manifests/nginx.go
+++ b/pkg/manifests/nginx.go
@@ -418,7 +418,7 @@ func newNginxIngressControllerDeployment(conf *config.Config, ingressConfig *Ngi
 
 	podAnnotations := map[string]string{}
 	if !conf.DisableOSM {
-		podAnnotations["openservicemesh.io/sidecar-injection"] = "enabled"
+		podAnnotations["openservicemesh.io/sidecar-injection"] = "disabled"
 	}
 
 	for k, v := range promAnnotations {
@@ -560,8 +560,8 @@ func newNginxIngressControllerHPA(conf *config.Config, ingressConfig *NginxIngre
 				Name:       ingressConfig.ResourceName,
 			},
 			MinReplicas:                    util.Int32Ptr(2),
-			MaxReplicas:                    100,
-			TargetCPUUtilizationPercentage: util.Int32Ptr(80),
+			MaxReplicas:                    500,
+			TargetCPUUtilizationPercentage: util.Int32Ptr(70),
 		},
 	}
 }

--- a/pkg/manifests/nginx.go
+++ b/pkg/manifests/nginx.go
@@ -417,9 +417,6 @@ func newNginxIngressControllerDeployment(conf *config.Config, ingressConfig *Ngi
 	}
 
 	podAnnotations := map[string]string{}
-	if !conf.DisableOSM {
-		//podAnnotations["openservicemesh.io/sidecar-injection"] = "disabled"
-	}
 
 	for k, v := range promAnnotations {
 		podAnnotations[k] = v


### PR DESCRIPTION
# Description

Our scale tests revealed that, at scale, 80% target CPU and 100 max replicas for the autoscaler isn't sufficient in some scenarios.

In short, I concluded that this was due to nginx waiting too long to scale and overcompensating by creating too many replicas too quickly, which suddenly had to be drained and removed when the load evened out/was no longer ramping up, which led to worse performance in our tests.

In the long run, we'll need to make both of these fields customizable by our end users, but in the meantime, this is a good temporary fix to allow app routing to operate well at scale.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Via scale tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
