### PR TITLE
switch so standard acr sku for e2e

### DIFF
--- a/testing/e2e/clients/acr.go
+++ b/testing/e2e/clients/acr.go
@@ -59,7 +59,7 @@ func NewAcr(ctx context.Context, subscriptionId, resourceGroup, name, location s
 	r := &armcontainerregistry.Registry{
 		Location: to.Ptr(location),
 		SKU: &armcontainerregistry.SKU{
-			Name: to.Ptr(armcontainerregistry.SKUNameBasic),
+			Name: to.Ptr(armcontainerregistry.SKUNameStandard),
 		},
 	}
 	poller, err := factory.NewRegistriesClient().BeginCreate(ctx, resourceGroup, name, *r, nil)


### PR DESCRIPTION
# Description

swaps us to standard acr sku for e2e. we get random acr failures in our e2e testing https://github.com/Azure/aks-app-routing-operator/actions/runs/8360908558/job/22887710325

I'm hoping standard sku helps this. Most relevant is the upload bandwidth being increased

https://learn.microsoft.com/en-us/azure/container-registry/container-registry-skus#service-tier-features-and-limits 