### PR TITLE
deduplicate dns zones passed to operator

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -154,7 +154,7 @@ func (c *Config) ParseAndValidateZoneIDs(zonesString string) error {
 			if c.PrivateZoneConfig.ZoneIds == nil {
 				c.PrivateZoneConfig.ZoneIds = map[string]struct{}{}
 			}
-			c.PrivateZoneConfig.ZoneIds[zoneId] = struct{}{}
+			c.PrivateZoneConfig.ZoneIds[strings.ToLower(zoneId)] = struct{}{} // azure resource names are case insensitive
 		case PublicZoneType:
 			// it's a public zone
 			if err := validateSubAndRg(parsedZone, c.PublicZoneConfig.Subscription, c.PublicZoneConfig.ResourceGroup); err != nil {
@@ -167,7 +167,7 @@ func (c *Config) ParseAndValidateZoneIDs(zonesString string) error {
 			if c.PublicZoneConfig.ZoneIds == nil {
 				c.PublicZoneConfig.ZoneIds = map[string]struct{}{}
 			}
-			c.PublicZoneConfig.ZoneIds[zoneId] = struct{}{}
+			c.PublicZoneConfig.ZoneIds[strings.ToLower(zoneId)] = struct{}{} // azure resource names are case insensitive
 		default:
 			return fmt.Errorf("while parsing dns zone resource ID %s: detected invalid resource type %s", zoneId, parsedZone.ResourceType)
 		}
@@ -177,7 +177,7 @@ func (c *Config) ParseAndValidateZoneIDs(zonesString string) error {
 }
 
 func validateSubAndRg(parsedZone azure.Resource, subscription, resourceGroup string) error {
-	if subscription != "" && parsedZone.SubscriptionID != subscription {
+	if subscription != "" && !strings.EqualFold(parsedZone.SubscriptionID, subscription) {
 		return fmt.Errorf("while parsing resource IDs for %s: detected multiple subscriptions %s and %s", parsedZone.ResourceType, parsedZone.SubscriptionID, subscription)
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -49,7 +49,7 @@ func init() {
 type DnsZoneConfig struct {
 	Subscription  string
 	ResourceGroup string
-	ZoneIds       []string
+	ZoneIds       map[string]struct{}
 }
 
 type Config struct {
@@ -127,7 +127,6 @@ func (c *Config) Validate() error {
 }
 
 func (c *Config) ParseAndValidateZoneIDs(zonesString string) error {
-
 	c.PrivateZoneConfig = DnsZoneConfig{}
 	c.PublicZoneConfig = DnsZoneConfig{}
 
@@ -151,7 +150,11 @@ func (c *Config) ParseAndValidateZoneIDs(zonesString string) error {
 
 			c.PrivateZoneConfig.Subscription = parsedZone.SubscriptionID
 			c.PrivateZoneConfig.ResourceGroup = parsedZone.ResourceGroup
-			c.PrivateZoneConfig.ZoneIds = append(c.PrivateZoneConfig.ZoneIds, zoneId)
+
+			if c.PrivateZoneConfig.ZoneIds == nil {
+				c.PrivateZoneConfig.ZoneIds = map[string]struct{}{}
+			}
+			c.PrivateZoneConfig.ZoneIds[zoneId] = struct{}{}
 		case PublicZoneType:
 			// it's a public zone
 			if err := validateSubAndRg(parsedZone, c.PublicZoneConfig.Subscription, c.PublicZoneConfig.ResourceGroup); err != nil {
@@ -160,7 +163,11 @@ func (c *Config) ParseAndValidateZoneIDs(zonesString string) error {
 
 			c.PublicZoneConfig.Subscription = parsedZone.SubscriptionID
 			c.PublicZoneConfig.ResourceGroup = parsedZone.ResourceGroup
-			c.PublicZoneConfig.ZoneIds = append(c.PublicZoneConfig.ZoneIds, zoneId)
+
+			if c.PublicZoneConfig.ZoneIds == nil {
+				c.PublicZoneConfig.ZoneIds = map[string]struct{}{}
+			}
+			c.PublicZoneConfig.ZoneIds[zoneId] = struct{}{}
 		default:
 			return fmt.Errorf("while parsing dns zone resource ID %s: detected invalid resource type %s", zoneId, parsedZone.ResourceType)
 		}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Azure/aks-app-routing-operator/pkg/util"
 	"github.com/stretchr/testify/require"
 )
 
@@ -277,61 +278,73 @@ func TestConfigValidate(t *testing.T) {
 var (
 	privateZoneOne = "/subscriptions/test-private-subscription/resourceGroups/test-rg-private/providers/Microsoft.Network/privatednszones/test-one.com"
 	privateZoneTwo = "/subscriptions/test-private-subscription/resourceGroups/test-rg-private/providers/Microsoft.Network/privatednszones/test-two.com"
-	privateZones   = []string{privateZoneOne, privateZoneTwo}
+	privateZones   = map[string]struct{}{
+		privateZoneOne: {},
+		privateZoneTwo: {},
+	}
 
 	publicZoneOne = "/subscriptions/test-public-subscription/resourceGroups/test-rg-public/providers/Microsoft.Network/dnszones/test-one.com"
 	publicZoneTwo = "/subscriptions/test-public-subscription/resourceGroups/test-rg-public/providers/Microsoft.Network/dnszones/test-two.com"
-	publicZones   = []string{publicZoneOne, publicZoneTwo}
+	publicZones   = map[string]struct{}{
+		publicZoneOne: {},
+		publicZoneTwo: {},
+	}
 
 	parseTestCases = []struct {
 		name                 string
 		zonesString          string
 		expectedError        error
-		expectedPrivateZones []string
-		expectedPublicZones  []string
+		expectedPrivateZones map[string]struct{}
+		expectedPublicZones  map[string]struct{}
 	}{
 		{
 			name:                 "full",
-			zonesString:          strings.Join(append(privateZones, publicZones...), ","),
+			zonesString:          strings.Join(append(util.Keys(privateZones), util.Keys(publicZones)...), ","),
 			expectedPrivateZones: privateZones,
 			expectedPublicZones:  publicZones,
 		},
 		{
 			name:                 "private-only",
-			zonesString:          strings.Join(privateZones, ","),
+			zonesString:          strings.Join(util.Keys(privateZones), ","),
 			expectedPrivateZones: privateZones,
 			expectedPublicZones:  nil,
 		},
 		{
 			name:                 "public-only",
-			zonesString:          strings.Join(publicZones, ","),
+			zonesString:          strings.Join(util.Keys(publicZones), ","),
 			expectedPrivateZones: nil,
 			expectedPublicZones:  publicZones,
 		},
 		{
+			name:                 "full-with-duplicates",
+			zonesString:          strings.Join(append(util.Keys(privateZones), append([]string{publicZoneOne, publicZoneTwo}, util.Keys(publicZones)...)...), ","),
+			expectedPrivateZones: privateZones,
+			expectedPublicZones:  publicZones,
+		},
+		{
 			name:          "bad-provider",
-			zonesString:   strings.Join(publicZones, ",") + ",/subscriptions/test-private-subscription/resourceGroups/test-rg-private/providers/Microsoft.FakeRP/privatednszones/test-one.com",
+			zonesString:   strings.Join(util.Keys(publicZones), ",") + ",/subscriptions/test-private-subscription/resourceGroups/test-rg-private/providers/Microsoft.FakeRP/privatednszones/test-one.com",
 			expectedError: errors.New("invalid resource provider Microsoft.FakeRP from zone /subscriptions/test-private-subscription/resourceGroups/test-rg-private/providers/Microsoft.FakeRP/privatednszones/test-one.com: resource ID must be a public or private DNS Zone resource ID from provider Microsoft.Network"),
 		},
 		{
 			name:          "bad-resource-type",
-			zonesString:   strings.Join(publicZones, ",") + ",/subscriptions/test-private-subscription/resourceGroups/test-rg-private/providers/Microsoft.Network/hybriddnszones/test-one.com",
+			zonesString:   strings.Join(util.Keys(publicZones), ",") + ",/subscriptions/test-private-subscription/resourceGroups/test-rg-private/providers/Microsoft.Network/hybriddnszones/test-one.com",
 			expectedError: errors.New("while parsing dns zone resource ID /subscriptions/test-private-subscription/resourceGroups/test-rg-private/providers/Microsoft.Network/hybriddnszones/test-one.com: detected invalid resource type hybriddnszones"),
 		},
 		{
 			name:          "bad-resource-group",
-			zonesString:   strings.Join(append(privateZones, publicZones...), ",") + ",/subscriptions/test-private-subscription/resourceGroups/another-rg-private/providers/Microsoft.Network/privatednszones/test-two.com",
+			zonesString:   strings.Join(append(util.Keys(privateZones), util.Keys(publicZones)...), ",") + ",/subscriptions/test-private-subscription/resourceGroups/another-rg-private/providers/Microsoft.Network/privatednszones/test-two.com",
 			expectedError: errors.New("while parsing resource IDs for privatednszones: detected multiple resource groups another-rg-private and test-rg-private"),
 		},
 		{
 			name:                 "ok-resource-group",
-			zonesString:          strings.Join(append(privateZones, publicZones...), ",") + ",/subscriptions/test-private-subscription/resourceGroups/TEST-RG-PRIVATE/providers/Microsoft.Network/privatednszones/test-two.com",
+			zonesString:          strings.Join(append(util.Keys(privateZones), util.Keys(publicZones)...), ",") + ",/subscriptions/test-private-subscription/resourceGroups/TEST-RG-PRIVATE/providers/Microsoft.Network/privatednszones/test-two.com",
 			expectedPublicZones:  publicZones,
-			expectedPrivateZones: append(privateZones, "/subscriptions/test-private-subscription/resourceGroups/TEST-RG-PRIVATE/providers/Microsoft.Network/privatednszones/test-two.com"),
+			expectedPrivateZones: util.MergeMaps(privateZones, map[string]struct{}{"/subscriptions/test-private-subscription/resourceGroups/TEST-RG-PRIVATE/providers/Microsoft.Network/privatednszones/test-two.com": {}}),
 		},
 		{
 			name:          "bad-subscription",
-			zonesString:   strings.Join(append(privateZones, publicZones...), ",") + ",/subscriptions/another-public-subscription/resourceGroups/test-rg-public/providers/Microsoft.Network/dnszones/test-two.com",
+			zonesString:   strings.Join(append(util.Keys(privateZones), util.Keys(publicZones)...), ",") + ",/subscriptions/another-public-subscription/resourceGroups/test-rg-public/providers/Microsoft.Network/dnszones/test-two.com",
 			expectedError: errors.New("while parsing resource IDs for dnszones: detected multiple subscriptions another-public-subscription and test-public-subscription"),
 		},
 	}

--- a/pkg/controller/dns/external_dns.go
+++ b/pkg/controller/dns/external_dns.go
@@ -97,7 +97,7 @@ func publicConfig(conf *config.Config) *manifests.ExternalDnsConfig {
 		Subscription:       conf.PublicZoneConfig.Subscription,
 		ResourceGroup:      conf.PublicZoneConfig.ResourceGroup,
 		Provider:           manifests.PublicProvider,
-		DnsZoneResourceIDs: conf.PublicZoneConfig.ZoneIds,
+		DnsZoneResourceIDs: util.Keys(conf.PublicZoneConfig.ZoneIds),
 	}
 }
 
@@ -107,7 +107,7 @@ func privateConfig(conf *config.Config) *manifests.ExternalDnsConfig {
 		Subscription:       conf.PrivateZoneConfig.Subscription,
 		ResourceGroup:      conf.PrivateZoneConfig.ResourceGroup,
 		Provider:           manifests.PrivateProvider,
-		DnsZoneResourceIDs: conf.PrivateZoneConfig.ZoneIds,
+		DnsZoneResourceIDs: util.Keys(conf.PrivateZoneConfig.ZoneIds),
 	}
 }
 

--- a/pkg/controller/dns/external_dns_test.go
+++ b/pkg/controller/dns/external_dns_test.go
@@ -36,7 +36,7 @@ var (
 		PublicZoneConfig: config.DnsZoneConfig{
 			Subscription:  "subscription",
 			ResourceGroup: "resourcegroup",
-			ZoneIds:       []string{"/subscriptions/subscription/resourceGroups/resourcegroup/providers/Microsoft.Network/publicdnszones/test.com"},
+			ZoneIds:       map[string]struct{}{"/subscriptions/subscription/resourceGroups/resourcegroup/providers/Microsoft.Network/publicdnszones/test.com": {}},
 		},
 	}
 	onlyPrivZones = config.Config{
@@ -45,7 +45,7 @@ var (
 		PrivateZoneConfig: config.DnsZoneConfig{
 			Subscription:  "subscription",
 			ResourceGroup: "resourcegroup",
-			ZoneIds:       []string{"/subscriptions/subscription/resourceGroups/resourcegroup/providers/Microsoft.Network/privatednszones/test.com"},
+			ZoneIds:       map[string]struct{}{"/subscriptions/subscription/resourceGroups/resourcegroup/providers/Microsoft.Network/privatednszones/test.com": {}},
 		},
 	}
 	allZones = config.Config{
@@ -53,12 +53,12 @@ var (
 		PublicZoneConfig: config.DnsZoneConfig{
 			Subscription:  "subscription",
 			ResourceGroup: "resourcegroup",
-			ZoneIds:       []string{"/subscriptions/subscription/resourceGroups/resourcegroup/providers/Microsoft.Network/publicdnszones/test.com"},
+			ZoneIds:       map[string]struct{}{"/subscriptions/subscription/resourceGroups/resourcegroup/providers/Microsoft.Network/publicdnszones/test.com": {}},
 		},
 		PrivateZoneConfig: config.DnsZoneConfig{
 			Subscription:  "subscription",
 			ResourceGroup: "resourcegroup",
-			ZoneIds:       []string{"/subscriptions/subscription/resourceGroups/resourcegroup/providers/Microsoft.Network/privatednszones/test.com"},
+			ZoneIds:       map[string]struct{}{"/subscriptions/subscription/resourceGroups/resourcegroup/providers/Microsoft.Network/privatednszones/test.com": {}},
 		},
 	}
 	gvr1 = schema.GroupVersionResource{
@@ -98,7 +98,7 @@ func TestPublicConfig(t *testing.T) {
 				Subscription:       allZones.PublicZoneConfig.Subscription,
 				ResourceGroup:      allZones.PublicZoneConfig.ResourceGroup,
 				Provider:           manifests.PublicProvider,
-				DnsZoneResourceIDs: allZones.PublicZoneConfig.ZoneIds,
+				DnsZoneResourceIDs: util.Keys(allZones.PublicZoneConfig.ZoneIds),
 			},
 		},
 		{
@@ -109,7 +109,7 @@ func TestPublicConfig(t *testing.T) {
 				Subscription:       onlyPrivZones.PublicZoneConfig.Subscription,
 				ResourceGroup:      onlyPrivZones.PublicZoneConfig.ResourceGroup,
 				Provider:           manifests.PublicProvider,
-				DnsZoneResourceIDs: onlyPrivZones.PublicZoneConfig.ZoneIds,
+				DnsZoneResourceIDs: util.Keys(onlyPrivZones.PublicZoneConfig.ZoneIds),
 			},
 		},
 	}
@@ -140,7 +140,7 @@ func TestPrivateConfig(t *testing.T) {
 				Subscription:       allZones.PrivateZoneConfig.Subscription,
 				ResourceGroup:      allZones.PrivateZoneConfig.ResourceGroup,
 				Provider:           manifests.PrivateProvider,
-				DnsZoneResourceIDs: allZones.PrivateZoneConfig.ZoneIds,
+				DnsZoneResourceIDs: util.Keys(allZones.PrivateZoneConfig.ZoneIds),
 			},
 		},
 		{
@@ -151,7 +151,7 @@ func TestPrivateConfig(t *testing.T) {
 				Subscription:       onlyPrivZones.PrivateZoneConfig.Subscription,
 				ResourceGroup:      onlyPrivZones.PrivateZoneConfig.ResourceGroup,
 				Provider:           manifests.PrivateProvider,
-				DnsZoneResourceIDs: onlyPrivZones.PrivateZoneConfig.ZoneIds,
+				DnsZoneResourceIDs: util.Keys(onlyPrivZones.PrivateZoneConfig.ZoneIds),
 			},
 		},
 	}

--- a/pkg/manifests/external_dns_test.go
+++ b/pkg/manifests/external_dns_test.go
@@ -2,6 +2,7 @@ package manifests
 
 import (
 	"path"
+	"strings"
 	"testing"
 	"time"
 
@@ -11,12 +12,12 @@ import (
 )
 
 var (
-	publicZoneOne = "/subscriptions/test-subscription/resourceGroups/test-rg-private/providers/Microsoft.Network/dnszones/test-one.com"
-	publicZoneTwo = "/subscriptions/test-subscription/resourceGroups/test-rg-private/providers/Microsoft.Network/dnszones/test-two.com"
+	publicZoneOne = strings.ToLower("/subscriptions/test-subscription/resourceGroups/test-rg-private/providers/Microsoft.Network/dnszones/test-one.com")
+	publicZoneTwo = strings.ToLower("/subscriptions/test-subscription/resourceGroups/test-rg-private/providers/Microsoft.Network/dnszones/test-two.com")
 	publicZones   = []string{publicZoneOne, publicZoneTwo}
 
-	privateZoneOne = "/subscriptions/test-subscription/resourceGroups/test-rg-private/providers/Microsoft.Network/privatednszones/test-three.com"
-	privateZoneTwo = "/subscriptions/test-subscription/resourceGroups/test-rg-private/providers/Microsoft.Network/privatednszones/test-four.com"
+	privateZoneOne = strings.ToLower("/subscriptions/test-subscription/resourceGroups/test-rg-private/providers/Microsoft.Network/privatednszones/test-three.com")
+	privateZoneTwo = strings.ToLower("/subscriptions/test-subscription/resourceGroups/test-rg-private/providers/Microsoft.Network/privatednszones/test-four.com")
 	privateZones   = []string{privateZoneOne, privateZoneTwo}
 
 	clusterUid = "test-cluster-uid"

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -69,3 +69,13 @@ func MergeMaps[M ~map[K]V, K comparable, V any](src ...M) M {
 	}
 	return merged
 }
+
+// Keys returns the keys in a map
+func Keys[K comparable, v any](m map[K]v) []K {
+	keys := make([]K, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+
+	return keys
+}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -1,0 +1,58 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestKeys(t *testing.T) {
+	type Case[K comparable, v any] struct {
+		name     string
+		m        map[K]v
+		expected []K
+	}
+
+	cases := []Case[string, struct{}]{
+		{
+			name:     "nil",
+			m:        nil,
+			expected: []string{},
+		},
+		{
+			name:     "map",
+			m:        map[string]struct{}{},
+			expected: []string{},
+		},
+		{
+			name:     "one key",
+			m:        map[string]struct{}{"one": {}},
+			expected: []string{"one"},
+		},
+		{
+			name: "multiple keys",
+			m: map[string]struct{}{
+				"one":   {},
+				"two":   {},
+				"three": {},
+			},
+			expected: []string{"one", "two", "three"},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := Keys(c.m)
+			for _, expected := range c.expected {
+				ok := false
+				for _, actual := range got {
+					if actual == expected {
+						ok = true
+					}
+				}
+
+				require.True(t, ok, "got must contain %s", expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description

Deduplicates any dns zones passed to the operator. Will need similar logic of some form in RP too.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Locally, e2e, unit

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
