### PR TITLE
bump nginx to 1.10.0

### DIFF
--- a/pkg/manifests/fixtures/nginx/full-with-replicas.json
+++ b/pkg/manifests/fixtures/nginx/full-with-replicas.json
@@ -460,7 +460,7 @@
             "containers": [
               {
                 "name": "controller",
-                "image": "test-registry/oss/kubernetes/ingress/nginx-ingress-controller:v1.9.4",
+                "image": "test-registry/oss/kubernetes/ingress/nginx-ingress-controller:v1.10.0",
                 "args": [
                   "/nginx-ingress-controller",
                   "--ingress-class=webapprouting.kubernetes.azure.com",

--- a/pkg/manifests/fixtures/nginx/full-with-target-cpu.json
+++ b/pkg/manifests/fixtures/nginx/full-with-target-cpu.json
@@ -460,7 +460,7 @@
             "containers": [
               {
                 "name": "controller",
-                "image": "test-registry/oss/kubernetes/ingress/nginx-ingress-controller:v1.9.4",
+                "image": "test-registry/oss/kubernetes/ingress/nginx-ingress-controller:v1.10.0",
                 "args": [
                   "/nginx-ingress-controller",
                   "--ingress-class=webapprouting.kubernetes.azure.com",

--- a/pkg/manifests/fixtures/nginx/full.json
+++ b/pkg/manifests/fixtures/nginx/full.json
@@ -460,7 +460,7 @@
             "containers": [
               {
                 "name": "controller",
-                "image": "test-registry/oss/kubernetes/ingress/nginx-ingress-controller:v1.9.4",
+                "image": "test-registry/oss/kubernetes/ingress/nginx-ingress-controller:v1.10.0",
                 "args": [
                   "/nginx-ingress-controller",
                   "--ingress-class=webapprouting.kubernetes.azure.com",

--- a/pkg/manifests/fixtures/nginx/internal-with-ssl-cert.json
+++ b/pkg/manifests/fixtures/nginx/internal-with-ssl-cert.json
@@ -459,7 +459,7 @@
             "containers": [
               {
                 "name": "controller",
-                "image": "test-registry/oss/kubernetes/ingress/nginx-ingress-controller:v1.9.4",
+                "image": "test-registry/oss/kubernetes/ingress/nginx-ingress-controller:v1.10.0",
                 "args": [
                   "/nginx-ingress-controller",
                   "--ingress-class=nginx-private",

--- a/pkg/manifests/fixtures/nginx/internal.json
+++ b/pkg/manifests/fixtures/nginx/internal.json
@@ -459,7 +459,7 @@
             "containers": [
               {
                 "name": "controller",
-                "image": "test-registry/oss/kubernetes/ingress/nginx-ingress-controller:v1.9.4",
+                "image": "test-registry/oss/kubernetes/ingress/nginx-ingress-controller:v1.10.0",
                 "args": [
                   "/nginx-ingress-controller",
                   "--ingress-class=nginx-private",

--- a/pkg/manifests/fixtures/nginx/kube-system.json
+++ b/pkg/manifests/fixtures/nginx/kube-system.json
@@ -447,7 +447,7 @@
             "containers": [
               {
                 "name": "controller",
-                "image": "test-registry/oss/kubernetes/ingress/nginx-ingress-controller:v1.9.4",
+                "image": "test-registry/oss/kubernetes/ingress/nginx-ingress-controller:v1.10.0",
                 "args": [
                   "/nginx-ingress-controller",
                   "--ingress-class=webapprouting.kubernetes.azure.com",

--- a/pkg/manifests/fixtures/nginx/no-ownership.json
+++ b/pkg/manifests/fixtures/nginx/no-ownership.json
@@ -460,7 +460,7 @@
             "containers": [
               {
                 "name": "controller",
-                "image": "test-registry/oss/kubernetes/ingress/nginx-ingress-controller:v1.9.4",
+                "image": "test-registry/oss/kubernetes/ingress/nginx-ingress-controller:v1.10.0",
                 "args": [
                   "/nginx-ingress-controller",
                   "--ingress-class=webapprouting.kubernetes.azure.com",

--- a/pkg/manifests/fixtures/nginx/optional-features-disabled.json
+++ b/pkg/manifests/fixtures/nginx/optional-features-disabled.json
@@ -456,7 +456,7 @@
             "containers": [
               {
                 "name": "controller",
-                "image": "test-registry/oss/kubernetes/ingress/nginx-ingress-controller:v1.9.4",
+                "image": "test-registry/oss/kubernetes/ingress/nginx-ingress-controller:v1.10.0",
                 "args": [
                   "/nginx-ingress-controller",
                   "--ingress-class=webapprouting.kubernetes.azure.com",

--- a/pkg/manifests/nginx.go
+++ b/pkg/manifests/nginx.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	controllerImageTag             = "v1.9.4"
+	controllerImageTag             = "v1.10.0"
 	prom                           = "prometheus"
 	IngressControllerComponentName = "ingress-controller"
 )


### PR DESCRIPTION
# Description

Bumps nginx to 1.10.0. Will be released tied to k8s minor version release for aks so we follow the addon breaking change policy.

https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.10.0

The breaking changes for our customers are
- This version dropped Opentracing and zipkin modules, just Opentelemetry is supported as of this release
- This version dropped support for GeoIP (legacy). Only GeoIP2 is supported

This will be clearly communicated when this is released. 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

e2e, unit, locally

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
