### PR TITLE
bump to external dns 0.13.5

### DIFF
--- a/pkg/manifests/external_dns.go
+++ b/pkg/manifests/external_dns.go
@@ -250,7 +250,7 @@ func newExternalDNSDeployment(conf *config.Config, externalDnsConfig *ExternalDn
 					ServiceAccountName: externalDnsConfig.Provider.ResourceName(),
 					Containers: []corev1.Container{*withLivenessProbeMatchingReadiness(withTypicalReadinessProbe(7979, &corev1.Container{
 						Name:  "controller",
-						Image: path.Join(conf.Registry, "/oss/kubernetes/external-dns:v0.13.5-patched"),
+						Image: path.Join(conf.Registry, "/oss/kubernetes/external-dns:v0.13.5-5"),
 						Args: append([]string{
 							"--provider=" + externalDnsConfig.Provider.String(),
 							"--source=ingress",

--- a/pkg/manifests/external_dns.go
+++ b/pkg/manifests/external_dns.go
@@ -26,7 +26,7 @@ const (
 	replicas                = 1 // this must stay at 1 unless external-dns adds support for multiple replicas https://github.com/kubernetes-sigs/external-dns/issues/2430
 	k8sNameKey              = "app.kubernetes.io/name"
 	externalDnsResourceName = "external-dns"
-	txtWildcardReplacement  = "wildcard"
+	txtWildcardReplacement  = "approutingwildcard"
 )
 
 var (

--- a/pkg/manifests/external_dns.go
+++ b/pkg/manifests/external_dns.go
@@ -250,7 +250,7 @@ func newExternalDNSDeployment(conf *config.Config, externalDnsConfig *ExternalDn
 					ServiceAccountName: externalDnsConfig.Provider.ResourceName(),
 					Containers: []corev1.Container{*withLivenessProbeMatchingReadiness(withTypicalReadinessProbe(7979, &corev1.Container{
 						Name:  "controller",
-						Image: path.Join(conf.Registry, "/oss/kubernetes/external-dns:v0.13.5"),
+						Image: path.Join(conf.Registry, "/oss/kubernetes/external-dns:v0.13.5-patched"),
 						Args: append([]string{
 							"--provider=" + externalDnsConfig.Provider.String(),
 							"--source=ingress",

--- a/pkg/manifests/external_dns.go
+++ b/pkg/manifests/external_dns.go
@@ -26,6 +26,7 @@ const (
 	replicas                = 1 // this must stay at 1 unless external-dns adds support for multiple replicas https://github.com/kubernetes-sigs/external-dns/issues/2430
 	k8sNameKey              = "app.kubernetes.io/name"
 	externalDnsResourceName = "external-dns"
+	txtWildcardReplacement  = "wildcard"
 )
 
 var (
@@ -256,6 +257,7 @@ func newExternalDNSDeployment(conf *config.Config, externalDnsConfig *ExternalDn
 							"--source=ingress",
 							"--interval=" + conf.DnsSyncInterval.String(),
 							"--txt-owner-id=" + conf.ClusterUid,
+							"--txt-wildcard-replacement=" + txtWildcardReplacement,
 						}, domainFilters...),
 						VolumeMounts: []corev1.VolumeMount{{
 							Name:      "azure-config",

--- a/pkg/manifests/external_dns.go
+++ b/pkg/manifests/external_dns.go
@@ -250,7 +250,7 @@ func newExternalDNSDeployment(conf *config.Config, externalDnsConfig *ExternalDn
 					ServiceAccountName: externalDnsConfig.Provider.ResourceName(),
 					Containers: []corev1.Container{*withLivenessProbeMatchingReadiness(withTypicalReadinessProbe(7979, &corev1.Container{
 						Name:  "controller",
-						Image: path.Join(conf.Registry, "/oss/kubernetes/external-dns:v0.11.0.2"),
+						Image: path.Join(conf.Registry, "/oss/kubernetes/external-dns:v0.13.5"),
 						Args: append([]string{
 							"--provider=" + externalDnsConfig.Provider.String(),
 							"--source=ingress",

--- a/pkg/manifests/fixtures/external_dns/full.json
+++ b/pkg/manifests/fixtures/external_dns/full.json
@@ -162,7 +162,7 @@
             "containers": [
               {
                 "name": "controller",
-                "image": "/oss/kubernetes/external-dns:v0.11.0.2",
+                "image": "/oss/kubernetes/external-dns:v0.13.5",
                 "args": [
                   "--provider=azure",
                   "--source=ingress",
@@ -438,7 +438,7 @@
             "containers": [
               {
                 "name": "controller",
-                "image": "/oss/kubernetes/external-dns:v0.11.0.2",
+                "image": "/oss/kubernetes/external-dns:v0.13.5",
                 "args": [
                   "--provider=azure-private-dns",
                   "--source=ingress",

--- a/pkg/manifests/fixtures/external_dns/full.json
+++ b/pkg/manifests/fixtures/external_dns/full.json
@@ -168,6 +168,7 @@
                   "--source=ingress",
                   "--interval=3m0s",
                   "--txt-owner-id=test-cluster-uid",
+                  "--txt-wildcard-replacement=wildcard",
                   "--domain-filter=test-one.com",
                   "--domain-filter=test-two.com"
                 ],
@@ -444,6 +445,7 @@
                   "--source=ingress",
                   "--interval=3m0s",
                   "--txt-owner-id=test-cluster-uid",
+                  "--txt-wildcard-replacement=wildcard",
                   "--domain-filter=test-three.com",
                   "--domain-filter=test-four.com"
                 ],

--- a/pkg/manifests/fixtures/external_dns/full.json
+++ b/pkg/manifests/fixtures/external_dns/full.json
@@ -162,7 +162,7 @@
             "containers": [
               {
                 "name": "controller",
-                "image": "/oss/kubernetes/external-dns:v0.13.5-patched",
+                "image": "/oss/kubernetes/external-dns:v0.13.5-5",
                 "args": [
                   "--provider=azure",
                   "--source=ingress",
@@ -438,7 +438,7 @@
             "containers": [
               {
                 "name": "controller",
-                "image": "/oss/kubernetes/external-dns:v0.13.5-patched",
+                "image": "/oss/kubernetes/external-dns:v0.13.5-5",
                 "args": [
                   "--provider=azure-private-dns",
                   "--source=ingress",

--- a/pkg/manifests/fixtures/external_dns/full.json
+++ b/pkg/manifests/fixtures/external_dns/full.json
@@ -162,7 +162,7 @@
             "containers": [
               {
                 "name": "controller",
-                "image": "/oss/kubernetes/external-dns:v0.13.5",
+                "image": "/oss/kubernetes/external-dns:v0.13.5-patched",
                 "args": [
                   "--provider=azure",
                   "--source=ingress",
@@ -438,7 +438,7 @@
             "containers": [
               {
                 "name": "controller",
-                "image": "/oss/kubernetes/external-dns:v0.13.5",
+                "image": "/oss/kubernetes/external-dns:v0.13.5-patched",
                 "args": [
                   "--provider=azure-private-dns",
                   "--source=ingress",

--- a/pkg/manifests/fixtures/external_dns/full.json
+++ b/pkg/manifests/fixtures/external_dns/full.json
@@ -168,7 +168,7 @@
                   "--source=ingress",
                   "--interval=3m0s",
                   "--txt-owner-id=test-cluster-uid",
-                  "--txt-wildcard-replacement=wildcard",
+                  "--txt-wildcard-replacement=approutingwildcard",
                   "--domain-filter=test-one.com",
                   "--domain-filter=test-two.com"
                 ],
@@ -445,7 +445,7 @@
                   "--source=ingress",
                   "--interval=3m0s",
                   "--txt-owner-id=test-cluster-uid",
-                  "--txt-wildcard-replacement=wildcard",
+                  "--txt-wildcard-replacement=approutingwildcard",
                   "--domain-filter=test-three.com",
                   "--domain-filter=test-four.com"
                 ],

--- a/pkg/manifests/fixtures/external_dns/no-ownership.json
+++ b/pkg/manifests/fixtures/external_dns/no-ownership.json
@@ -162,7 +162,7 @@
             "containers": [
               {
                 "name": "controller",
-                "image": "/oss/kubernetes/external-dns:v0.11.0.2",
+                "image": "/oss/kubernetes/external-dns:v0.13.5",
                 "args": [
                   "--provider=azure",
                   "--source=ingress",

--- a/pkg/manifests/fixtures/external_dns/no-ownership.json
+++ b/pkg/manifests/fixtures/external_dns/no-ownership.json
@@ -162,7 +162,7 @@
             "containers": [
               {
                 "name": "controller",
-                "image": "/oss/kubernetes/external-dns:v0.13.5",
+                "image": "/oss/kubernetes/external-dns:v0.13.5-patched",
                 "args": [
                   "--provider=azure",
                   "--source=ingress",

--- a/pkg/manifests/fixtures/external_dns/no-ownership.json
+++ b/pkg/manifests/fixtures/external_dns/no-ownership.json
@@ -162,7 +162,7 @@
             "containers": [
               {
                 "name": "controller",
-                "image": "/oss/kubernetes/external-dns:v0.13.5-patched",
+                "image": "/oss/kubernetes/external-dns:v0.13.5-5",
                 "args": [
                   "--provider=azure",
                   "--source=ingress",

--- a/pkg/manifests/fixtures/external_dns/no-ownership.json
+++ b/pkg/manifests/fixtures/external_dns/no-ownership.json
@@ -168,7 +168,7 @@
                   "--source=ingress",
                   "--interval=3m0s",
                   "--txt-owner-id=test-cluster-uid",
-                  "--txt-wildcard-replacement=wildcard",
+                  "--txt-wildcard-replacement=approutingwildcard",
                   "--domain-filter=test-one.com",
                   "--domain-filter=test-two.com"
                 ],

--- a/pkg/manifests/fixtures/external_dns/no-ownership.json
+++ b/pkg/manifests/fixtures/external_dns/no-ownership.json
@@ -168,6 +168,7 @@
                   "--source=ingress",
                   "--interval=3m0s",
                   "--txt-owner-id=test-cluster-uid",
+                  "--txt-wildcard-replacement=wildcard",
                   "--domain-filter=test-one.com",
                   "--domain-filter=test-two.com"
                 ],

--- a/pkg/manifests/fixtures/external_dns/private.json
+++ b/pkg/manifests/fixtures/external_dns/private.json
@@ -162,7 +162,7 @@
             "containers": [
               {
                 "name": "controller",
-                "image": "/oss/kubernetes/external-dns:v0.11.0.2",
+                "image": "/oss/kubernetes/external-dns:v0.13.5",
                 "args": [
                   "--provider=azure-private-dns",
                   "--source=ingress",

--- a/pkg/manifests/fixtures/external_dns/private.json
+++ b/pkg/manifests/fixtures/external_dns/private.json
@@ -168,7 +168,7 @@
                   "--source=ingress",
                   "--interval=3m0s",
                   "--txt-owner-id=test-cluster-uid",
-                  "--txt-wildcard-replacement=wildcard",
+                  "--txt-wildcard-replacement=approutingwildcard",
                   "--domain-filter=test-three.com",
                   "--domain-filter=test-four.com"
                 ],

--- a/pkg/manifests/fixtures/external_dns/private.json
+++ b/pkg/manifests/fixtures/external_dns/private.json
@@ -162,7 +162,7 @@
             "containers": [
               {
                 "name": "controller",
-                "image": "/oss/kubernetes/external-dns:v0.13.5-patched",
+                "image": "/oss/kubernetes/external-dns:v0.13.5-5",
                 "args": [
                   "--provider=azure-private-dns",
                   "--source=ingress",

--- a/pkg/manifests/fixtures/external_dns/private.json
+++ b/pkg/manifests/fixtures/external_dns/private.json
@@ -162,7 +162,7 @@
             "containers": [
               {
                 "name": "controller",
-                "image": "/oss/kubernetes/external-dns:v0.13.5",
+                "image": "/oss/kubernetes/external-dns:v0.13.5-patched",
                 "args": [
                   "--provider=azure-private-dns",
                   "--source=ingress",

--- a/pkg/manifests/fixtures/external_dns/private.json
+++ b/pkg/manifests/fixtures/external_dns/private.json
@@ -168,6 +168,7 @@
                   "--source=ingress",
                   "--interval=3m0s",
                   "--txt-owner-id=test-cluster-uid",
+                  "--txt-wildcard-replacement=wildcard",
                   "--domain-filter=test-three.com",
                   "--domain-filter=test-four.com"
                 ],

--- a/pkg/manifests/fixtures/external_dns/short-sync-interval.json
+++ b/pkg/manifests/fixtures/external_dns/short-sync-interval.json
@@ -168,7 +168,7 @@
                   "--source=ingress",
                   "--interval=10s",
                   "--txt-owner-id=test-cluster-uid",
-                  "--txt-wildcard-replacement=wildcard",
+                  "--txt-wildcard-replacement=approutingwildcard",
                   "--domain-filter=test-one.com",
                   "--domain-filter=test-two.com"
                 ],
@@ -445,7 +445,7 @@
                   "--source=ingress",
                   "--interval=10s",
                   "--txt-owner-id=test-cluster-uid",
-                  "--txt-wildcard-replacement=wildcard",
+                  "--txt-wildcard-replacement=approutingwildcard",
                   "--domain-filter=test-three.com",
                   "--domain-filter=test-four.com"
                 ],

--- a/pkg/manifests/fixtures/external_dns/short-sync-interval.json
+++ b/pkg/manifests/fixtures/external_dns/short-sync-interval.json
@@ -162,7 +162,7 @@
             "containers": [
               {
                 "name": "controller",
-                "image": "/oss/kubernetes/external-dns:v0.11.0.2",
+                "image": "/oss/kubernetes/external-dns:v0.13.5",
                 "args": [
                   "--provider=azure",
                   "--source=ingress",
@@ -438,7 +438,7 @@
             "containers": [
               {
                 "name": "controller",
-                "image": "/oss/kubernetes/external-dns:v0.11.0.2",
+                "image": "/oss/kubernetes/external-dns:v0.13.5",
                 "args": [
                   "--provider=azure-private-dns",
                   "--source=ingress",

--- a/pkg/manifests/fixtures/external_dns/short-sync-interval.json
+++ b/pkg/manifests/fixtures/external_dns/short-sync-interval.json
@@ -162,7 +162,7 @@
             "containers": [
               {
                 "name": "controller",
-                "image": "/oss/kubernetes/external-dns:v0.13.5-patched",
+                "image": "/oss/kubernetes/external-dns:v0.13.5-5",
                 "args": [
                   "--provider=azure",
                   "--source=ingress",
@@ -438,7 +438,7 @@
             "containers": [
               {
                 "name": "controller",
-                "image": "/oss/kubernetes/external-dns:v0.13.5-patched",
+                "image": "/oss/kubernetes/external-dns:v0.13.5-5",
                 "args": [
                   "--provider=azure-private-dns",
                   "--source=ingress",

--- a/pkg/manifests/fixtures/external_dns/short-sync-interval.json
+++ b/pkg/manifests/fixtures/external_dns/short-sync-interval.json
@@ -162,7 +162,7 @@
             "containers": [
               {
                 "name": "controller",
-                "image": "/oss/kubernetes/external-dns:v0.13.5",
+                "image": "/oss/kubernetes/external-dns:v0.13.5-patched",
                 "args": [
                   "--provider=azure",
                   "--source=ingress",
@@ -438,7 +438,7 @@
             "containers": [
               {
                 "name": "controller",
-                "image": "/oss/kubernetes/external-dns:v0.13.5",
+                "image": "/oss/kubernetes/external-dns:v0.13.5-patched",
                 "args": [
                   "--provider=azure-private-dns",
                   "--source=ingress",

--- a/pkg/manifests/fixtures/external_dns/short-sync-interval.json
+++ b/pkg/manifests/fixtures/external_dns/short-sync-interval.json
@@ -168,6 +168,7 @@
                   "--source=ingress",
                   "--interval=10s",
                   "--txt-owner-id=test-cluster-uid",
+                  "--txt-wildcard-replacement=wildcard",
                   "--domain-filter=test-one.com",
                   "--domain-filter=test-two.com"
                 ],
@@ -444,6 +445,7 @@
                   "--source=ingress",
                   "--interval=10s",
                   "--txt-owner-id=test-cluster-uid",
+                  "--txt-wildcard-replacement=wildcard",
                   "--domain-filter=test-three.com",
                   "--domain-filter=test-four.com"
                 ],

--- a/testing/e2e/clients/akv.go
+++ b/testing/e2e/clients/akv.go
@@ -158,7 +158,7 @@ func LoadCert(name, id string) *Cert {
 	}
 }
 
-func (a *akv) CreateCertificate(ctx context.Context, name string, dnsnames []string, certOpts ...CertOpt) (*Cert, error) {
+func (a *akv) CreateCertificate(ctx context.Context, name string, cnName string, dnsnames []string, certOpts ...CertOpt) (*Cert, error) {
 	lgr := logger.FromContext(ctx).With("name", name, "dnsnames", dnsnames, "resourceGroup", a.resourceGroup, "subscriptionId", a.subscriptionId)
 	ctx = logger.WithContext(ctx, lgr)
 	lgr.Info("starting to create certificate")
@@ -210,7 +210,7 @@ func (a *akv) CreateCertificate(ctx context.Context, name string, dnsnames []str
 					to.Ptr(azcertificates.KeyUsageTypeKeyCertSign),
 					to.Ptr(azcertificates.KeyUsageTypeKeyEncipherment),
 				},
-				Subject: to.Ptr("CN=testcert"),
+				Subject: to.Ptr("CN=" + cnName),
 				SubjectAlternativeNames: &azcertificates.SubjectAlternativeNames{
 					DNSNames: dnsnamesPtr,
 				},

--- a/testing/e2e/infra/convert.go
+++ b/testing/e2e/infra/convert.go
@@ -23,7 +23,7 @@ func (p Provisioned) Loadable() (LoadableProvisioned, error) {
 	for i, zone := range p.Zones {
 		z, err := azure.ParseResourceID(zone.Zone.GetId())
 		if err != nil {
-			return LoadableProvisioned{}, fmt.Errorf("parsing zone resource id: %w", err)
+			return LoadableProvisioned{}, fmt.Errorf("parsing Zone resource id: %w", err)
 		}
 		zones[i] = withLoadableCert[LoadableZone]{
 			Zone: LoadableZone{
@@ -39,7 +39,7 @@ func (p Provisioned) Loadable() (LoadableProvisioned, error) {
 	for i, privateZone := range p.PrivateZones {
 		z, err := azure.ParseResourceID(privateZone.Zone.GetId())
 		if err != nil {
-			return LoadableProvisioned{}, fmt.Errorf("parsing private zone resource id: %w", err)
+			return LoadableProvisioned{}, fmt.Errorf("parsing private Zone resource id: %w", err)
 		}
 		privateZones[i] = withLoadableCert[azure.Resource]{
 			Zone:     z,
@@ -103,16 +103,16 @@ func ToProvisioned(l []LoadableProvisioned) ([]Provisioned, error) {
 }
 
 func (l LoadableProvisioned) Provisioned() (Provisioned, error) {
-	zs := make([]withCert[zone], len(l.Zones))
+	zs := make([]WithCert[Zone], len(l.Zones))
 	for i, z := range l.Zones {
-		zs[i] = withCert[zone]{
+		zs[i] = WithCert[Zone]{
 			Zone: clients.LoadZone(z.Zone.ResourceId, z.Zone.Nameservers),
 			Cert: clients.LoadCert(z.CertName, z.CertId),
 		}
 	}
-	pzs := make([]withCert[privateZone], len(l.PrivateZones))
+	pzs := make([]WithCert[PrivateZone], len(l.PrivateZones))
 	for i, pz := range l.PrivateZones {
-		pzs[i] = withCert[privateZone]{
+		pzs[i] = WithCert[PrivateZone]{
 			Zone: clients.LoadPrivateZone(pz.Zone),
 			Cert: clients.LoadCert(pz.CertName, pz.CertId),
 		}

--- a/testing/e2e/infra/provision.go
+++ b/testing/e2e/infra/provision.go
@@ -105,19 +105,19 @@ func (i *infra) Provision(ctx context.Context, tenantId, subscriptionId, applica
 		// that will change the loop variable capture to be the standard way loops work.
 		func(idx int) {
 			resEg.Go(func() error {
-				z, err := clients.NewZone(ctx, subscriptionId, i.ResourceGroup, fmt.Sprintf("zone-%d-%s", idx, i.Suffix))
+				z, err := clients.NewZone(ctx, subscriptionId, i.ResourceGroup, fmt.Sprintf("Zone-%d-%s", idx, i.Suffix))
 				if err != nil {
-					return logger.Error(lgr, fmt.Errorf("creating zone: %w", err))
+					return logger.Error(lgr, fmt.Errorf("creating Zone: %w", err))
 				}
 
 				<-kvDone
 
-				cert, err := ret.KeyVault.CreateCertificate(ctx, fmt.Sprintf("zone-%d", idx), z.GetName(), []string{z.GetName()})
+				cert, err := ret.KeyVault.CreateCertificate(ctx, fmt.Sprintf("Zone-%d", idx), z.GetName(), []string{z.GetName()})
 				if err != nil {
 					return logger.Error(lgr, fmt.Errorf("creating certificate: %w", err))
 				}
 
-				ret.Zones = append(ret.Zones, withCert[zone]{
+				ret.Zones = append(ret.Zones, WithCert[Zone]{
 					Zone: z,
 					Cert: cert,
 				})
@@ -128,9 +128,9 @@ func (i *infra) Provision(ctx context.Context, tenantId, subscriptionId, applica
 	for idx := 0; idx < lenPrivateZones; idx++ {
 		func(idx int) {
 			resEg.Go(func() error {
-				pz, err := clients.NewPrivateZone(ctx, subscriptionId, i.ResourceGroup, fmt.Sprintf("private-zone-%d-%s", idx, i.Suffix))
+				pz, err := clients.NewPrivateZone(ctx, subscriptionId, i.ResourceGroup, fmt.Sprintf("private-Zone-%d-%s", idx, i.Suffix))
 				if err != nil {
-					return logger.Error(lgr, fmt.Errorf("creating private zone: %w", err))
+					return logger.Error(lgr, fmt.Errorf("creating private Zone: %w", err))
 				}
 
 				<-kvDone
@@ -140,7 +140,7 @@ func (i *infra) Provision(ctx context.Context, tenantId, subscriptionId, applica
 					return logger.Error(lgr, fmt.Errorf("creating certificate: %w", err))
 				}
 
-				ret.PrivateZones = append(ret.PrivateZones, withCert[privateZone]{
+				ret.PrivateZones = append(ret.PrivateZones, WithCert[PrivateZone]{
 					Zone: pz,
 					Cert: cert,
 				})
@@ -157,7 +157,7 @@ func (i *infra) Provision(ctx context.Context, tenantId, subscriptionId, applica
 	var permEg errgroup.Group
 
 	for _, pz := range ret.PrivateZones {
-		func(pz withCert[privateZone]) {
+		func(pz WithCert[PrivateZone]) {
 			permEg.Go(func() error {
 				dns, err := pz.Zone.GetDnsZone(ctx)
 				if err != nil {
@@ -184,7 +184,7 @@ func (i *infra) Provision(ctx context.Context, tenantId, subscriptionId, applica
 	}
 
 	for _, z := range ret.Zones {
-		func(z withCert[zone]) {
+		func(z WithCert[Zone]) {
 			permEg.Go(func() error {
 				dns, err := z.Zone.GetDnsZone(ctx)
 				if err != nil {

--- a/testing/e2e/infra/provision.go
+++ b/testing/e2e/infra/provision.go
@@ -112,7 +112,7 @@ func (i *infra) Provision(ctx context.Context, tenantId, subscriptionId, applica
 
 				<-kvDone
 
-				cert, err := ret.KeyVault.CreateCertificate(ctx, fmt.Sprintf("cert-%d", idx), z.GetName(), []string{z.GetName()})
+				cert, err := ret.KeyVault.CreateCertificate(ctx, fmt.Sprintf("zone-%d", idx), z.GetName(), []string{z.GetName()})
 				if err != nil {
 					return logger.Error(lgr, fmt.Errorf("creating certificate: %w", err))
 				}

--- a/testing/e2e/infra/provision.go
+++ b/testing/e2e/infra/provision.go
@@ -89,12 +89,13 @@ func (i *infra) Provision(ctx context.Context, tenantId, subscriptionId, applica
 
 	kvDone := make(chan struct{})
 	resEg.Go(func() error {
+		defer close(kvDone)
+
 		ret.KeyVault, err = clients.NewAkv(ctx, tenantId, subscriptionId, i.ResourceGroup, "keyvault"+i.Suffix, i.Location)
 		if err != nil {
 			return logger.Error(lgr, fmt.Errorf("creating key vault: %w", err))
 		}
 
-		close(kvDone)
 		return nil
 	})
 

--- a/testing/e2e/infra/types.go
+++ b/testing/e2e/infra/types.go
@@ -57,14 +57,14 @@ type containerRegistry interface {
 	Identifier
 }
 
-type zone interface {
+type Zone interface {
 	GetDnsZone(ctx context.Context) (*armdns.Zone, error)
 	GetName() string
 	GetNameservers() []string
 	Identifier
 }
 
-type privateZone interface {
+type PrivateZone interface {
 	GetDnsZone(ctx context.Context) (*armprivatedns.PrivateZone, error)
 	LinkVnet(ctx context.Context, linkName, vnetId string) error
 	GetName() string
@@ -88,8 +88,8 @@ type cert interface {
 	GetId() string
 }
 
-// withCert is a resource with a tls certificate valid for that resource. This is used to bundle DNS Zones
-type withCert[T any] struct {
+// WithCert is a resource with a tls certificate valid for that resource. This is used to bundle DNS Zones
+type WithCert[T any] struct {
 	Zone T
 	Cert cert
 }
@@ -98,8 +98,8 @@ type Provisioned struct {
 	Name              string
 	Cluster           cluster
 	ContainerRegistry containerRegistry
-	Zones             []withCert[zone]
-	PrivateZones      []withCert[privateZone]
+	Zones             []WithCert[Zone]
+	PrivateZones      []WithCert[PrivateZone]
 	KeyVault          keyVault
 	ResourceGroup     resourceGroup
 	SubscriptionId    string

--- a/testing/e2e/manifests/clientServer.go
+++ b/testing/e2e/manifests/clientServer.go
@@ -13,8 +13,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-type Host int
-
 //go:embed embedded/client.go
 var clientContents string
 

--- a/testing/e2e/suites/basic.go
+++ b/testing/e2e/suites/basic.go
@@ -118,11 +118,11 @@ var clientServerTest = func(ctx context.Context, config *rest.Config, operator m
 		zoners = append(zoners, zoners...)
 	case manifests.DnsZoneCountMultiple:
 		for _, z := range infra.Zones {
-			zoners, err := toZoners(ctx, c, namespaces, z)
+			zs, err := toZoners(ctx, c, namespaces, z)
 			if err != nil {
 				return fmt.Errorf("converting to zoners: %w", err)
 			}
-			zoners = append(zoners, zoners...)
+			zoners = append(zoners, zs...)
 		}
 	}
 	switch operator.Zones.Private {
@@ -135,11 +135,11 @@ var clientServerTest = func(ctx context.Context, config *rest.Config, operator m
 		zoners = append(zoners, zoners...)
 	case manifests.DnsZoneCountMultiple:
 		for _, z := range infra.PrivateZones {
-			zoners, err := toPrivateZoners(ctx, c, namespaces, z, infra.Cluster.GetDnsServiceIp())
+			zs, err := toPrivateZoners(ctx, c, namespaces, z, infra.Cluster.GetDnsServiceIp())
 			if err != nil {
 				return fmt.Errorf("converting to zoners: %w", err)
 			}
-			zoners = append(zoners, zoners...)
+			zoners = append(zoners, zs...)
 		}
 	}
 
@@ -166,7 +166,7 @@ var clientServerTest = func(ctx context.Context, config *rest.Config, operator m
 			lgr = lgr.With("namespace", ns.Name)
 			ctx = logger.WithContext(ctx, lgr)
 
-			testingResources := manifests.ClientAndServer(ns.Name, zone.GetName(), zone.GetNameserver(), zone.GetCertId(), zone.GetHost(), zone.GetTlsHost())
+			testingResources := manifests.ClientAndServer(ns.Name, zone.GetName()[:40], zone.GetNameserver(), zone.GetCertId(), zone.GetHost(), zone.GetTlsHost())
 			if mod != nil {
 				if err := mod(testingResources.Ingress, testingResources.Service, zone); err != nil {
 					return fmt.Errorf("modifying ingress and service: %w", err)
@@ -216,12 +216,12 @@ func toZoners(ctx context.Context, cl client.Client, namespaces map[string]*core
 			tlsHost:    strings.ToLower(ns.Name) + "." + strings.TrimRight(name, "."),
 		},
 		zone{
-			name:       name + "wildcard",
+			name:       "wildcard" + name,
 			nameserver: nameserver,
 			certName:   certName,
 			certId:     certId,
 			host:       "wildcard." + strings.ToLower(ns.Name) + "." + strings.TrimRight(name, "."),
-			tlsHost:    "*" + strings.ToLower(ns.Name) + "." + strings.TrimRight(name, "."),
+			tlsHost:    "*." + strings.ToLower(ns.Name) + "." + strings.TrimRight(name, "."),
 		},
 	}, nil
 }
@@ -245,12 +245,12 @@ func toPrivateZoners(ctx context.Context, cl client.Client, namespaces map[strin
 			tlsHost:    strings.ToLower(ns.Name) + "." + strings.TrimRight(name, "."),
 		},
 		zone{
-			name:       name + "wildcard",
+			name:       "wildcard" + name,
 			nameserver: nameserver,
 			certName:   certName,
 			certId:     certId,
 			host:       "wildcard." + strings.ToLower(ns.Name) + "." + strings.TrimRight(name, "."),
-			tlsHost:    "*" + strings.ToLower(ns.Name) + "." + strings.TrimRight(name, "."),
+			tlsHost:    "*." + strings.ToLower(ns.Name) + "." + strings.TrimRight(name, "."),
 		},
 	}, nil
 }

--- a/testing/e2e/suites/nginxIngressController.go
+++ b/testing/e2e/suites/nginxIngressController.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/Azure/aks-app-routing-operator/pkg/controller/keyvault"
 	"time"
+
+	"github.com/Azure/aks-app-routing-operator/pkg/controller/keyvault"
 
 	secv1 "sigs.k8s.io/secrets-store-csi-driver/apis/v1"
 
@@ -315,7 +316,7 @@ func nicTests(in infra.Provisioned) []test {
 				}
 
 				// get keyvault uri
-				kvuri := in.Cert.GetId()
+				kvuri := in.Zones[0].Cert.GetId()
 
 				// create defaultSSLCert
 				defaultSSLCert := v1alpha1.DefaultSSLCertificate{

--- a/testing/e2e/suites/osm.go
+++ b/testing/e2e/suites/osm.go
@@ -74,7 +74,7 @@ func osmSuite(in infra.Provisioned) []test {
 					ingress = nil
 					annotations := service.GetAnnotations()
 					annotations["kubernetes.azure.com/ingress-host"] = z.GetNameserver()
-					annotations["kubernetes.azure.com/tls-cert-keyvault-uri"] = in.Cert.GetId()
+					annotations["kubernetes.azure.com/tls-cert-keyvault-uri"] = z.GetCertId()
 					service.SetAnnotations(annotations)
 
 					return nil

--- a/testing/e2e/tests/run.go
+++ b/testing/e2e/tests/run.go
@@ -69,11 +69,11 @@ func (t Ts) Run(ctx context.Context, infra infra.Provisioned) error {
 
 	publicZones := make([]string, len(infra.Zones))
 	for i, zone := range infra.Zones {
-		publicZones[i] = zone.GetId()
+		publicZones[i] = zone.Zone.GetId()
 	}
 	privateZones := make([]string, len(infra.PrivateZones))
 	for i, zone := range infra.PrivateZones {
-		privateZones[i] = zone.GetId()
+		privateZones[i] = zone.Zone.GetId()
 	}
 
 	for i, runStrategy := range ordered {


### PR DESCRIPTION
# Description

bumps us to external dns 0.13.5.

Need to land on this version before jumping to higher versions because of [this](https://github.com/kubernetes-sigs/external-dns/issues/3876). This is [documented by ExternalDNS](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.13.6).

We handle [this](https://github.com/kubernetes-sigs/external-dns/issues/2922) breaking change made by ExternalDNS that will come into affect as part of this bump. We mitigate the change by using the `--txt-wildcard-replacement=approutingwildcard` flag. This makes the chance of a collision all but impossible.

I also add e2e tests to cover the above wildcard case to prove it works.