### PR TITLE
set dev environment location randomly

### DIFF
--- a/devenv/tf/main.tf
+++ b/devenv/tf/main.tf
@@ -4,6 +4,11 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "= 3.43.0"
     }
+
+    random = {
+      source = "hashicorp/random"
+      version = "3.6.2"
+    }
   }
 }
 
@@ -15,10 +20,20 @@ provider "azurerm" {
   }
 }
 
+// randomly choose location to be less to resource limits on our subscription (they are at the location level)
+resource "random_shuffle" "locations" {
+  input = ["North Central US", "South Central US", "East US", "East US 2", "West US", "West US 2", "West US 3"]
+  result_count = 1
+}
+
 variable "location" {
   type = string
   description = "The Azure Region in which resources will be created"
-  default = "South Central US"
+  default = ""
+}
+
+locals {
+  location = var.location == "" ? random_shuffle.locations.result[0] : var.location
 }
 
 resource "random_string" "random" {

--- a/devenv/tf/resourcegroup.tf
+++ b/devenv/tf/resourcegroup.tf
@@ -1,6 +1,6 @@
 resource "azurerm_resource_group" "rg" {
   name     = "app-routing-dev-${random_string.random.result}"
-  location = var.location
+  location = local.location
   tags = {
     deletion_due_time  = time_static.provisiontime.unix + 36000, // keep resources for 10hr
     deletion_marked_by = "gc",
@@ -9,7 +9,7 @@ resource "azurerm_resource_group" "rg" {
 
 resource "azurerm_resource_group" "rg-public" {
   name     = "app-routing-dev-${random_string.random.result}-public"
-  location = var.location
+  location = local.location
   tags = {
     deletion_due_time  = time_static.provisiontime.unix + 36000, // keep resources for 10hr
     deletion_marked_by = "gc",
@@ -18,7 +18,7 @@ resource "azurerm_resource_group" "rg-public" {
 
 resource "azurerm_resource_group" "rg-private" {
   name     = "app-routing-dev-${random_string.random.result}-private"
-  location = var.location
+  location = local.location
   tags = {
     deletion_due_time  = time_static.provisiontime.unix + 36000, // keep resources for 10hr
     deletion_marked_by = "gc",

--- a/docs/local-testing.md
+++ b/docs/local-testing.md
@@ -13,6 +13,8 @@ You can easily provision a development environment to test your changes on.
 
 By default, the `make dev` command will create an environment with a public cluster using a public DNS Zone. However, two arguments can be specified to change the type of the cluster and/or the zone: `CLUSTER_TYPE` and `DNS_ZONE_TYPE`. For instance, to run a suite with a private cluster and a public zone, a user can run `	make dev CLUSTER_TYPE=private DNS_ZONE_TYPE=public`.
 
+Occasionally, the Cluster create might fail due to `AllocationFailed` when too many resources are used in a region. In this case, just repeat the steps required to make the dev environment since a location is chosen at random in each run.
+
 Region can be specified by exporting an env variable before running the `make dev` command. `export TF_VAR_location="East US"` sets the location to East US.
 
 This development environment is useful for manually interacting with App Routing during development.


### PR DESCRIPTION
# Description

sets the dev environment location randomly. Useful to avoid `AllocationFailed` due to resource limits by location.