### PR TITLE
swap to use var for public registry in trivy scanning

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -68,7 +68,7 @@ jobs:
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@d43c1f16c00cfd3978dde6c07f4bbcf9eb6993ca # v0.16.1
         with:
-          image-ref: '${{ secrets.AZURE_REGISTRY_SERVER }}/public/aks/aks-app-routing-operator:${{ inputs.version }}'
+          image-ref: '${{ vars.PUBLIC_REGISTRY }}/public/aks/aks-app-routing-operator:${{ inputs.version }}'
           format: 'table'
           exit-code: '1'
           ignore-unfixed: true

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@d43c1f16c00cfd3978dde6c07f4bbcf9eb6993ca # v0.16.1
         with:
-          image-ref: '${{ secrets.AZURE_REGISTRY_SERVER }}/aks/aks-app-routing-operator:${{ steps.changelog.outputs.version }}'
+          image-ref: '${{ vars.PUBLIC_REGISTRY }}/aks/aks-app-routing-operator:${{ steps.changelog.outputs.version }}'
           format: 'table'
           exit-code: '1'
           ignore-unfixed: true


### PR DESCRIPTION
# Description

fixes trivy scanning in our workflows. Example of this working [here](https://github.com/OliverMKing/aks-app-routing/actions/runs/9342622599/job/25711010258). login server is different from public servers.