### PR TITLE
lock release workflow behind prod environment

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,6 +15,7 @@ permissions:
 
 jobs: 
   release:
+    environment: prod
     runs-on: ["self-hosted", "1ES.Pool=${{ vars.RUNNER_BASE_NAME }}-ubuntu"]
     steps:
       # always read the changelog in main


### PR DESCRIPTION
# Description

locks release workflow behind prod environment. Requires specific approvers to approve any releases.