### PR TITLE
move trivy scan to pre-release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,35 @@ permissions:
   contents: write
 
 jobs: 
+  # validate ensures best practices are being followed before we release
+  validate:
+    runs-on: ubuntu-latest
+    env:
+      TAG: aks-app-routing-operator-validate:${{ inputs.version }}
+    steps:
+      # validate image from sha input
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.sha }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@16c0bc4a6e6ada2cfd8afd41d22d95379cf7c32a # v2.8.0
+
+      - name: Build image locally
+        run: docker buildx build --tag "${TAG}" .
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@595be6a0f6560a0a8fc419ddf630567fc623531d # v0.22.0
+        with:
+          image-ref: ${{ env.TAG }}
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH,MEDIUM'
+          # if we need to ignore a vulnerability we can use a .trivyignore and reference it here
+
   release:
+    needs: validate
     environment: prod
     runs-on: ["self-hosted", "1ES.Pool=${{ vars.RUNNER_BASE_NAME }}-ubuntu"]
     steps:
@@ -65,13 +93,3 @@ jobs:
         run: |
           TAG="${{ secrets.AZURE_REGISTRY_SERVER }}/public/aks/aks-app-routing-operator:$VERSION"
           docker buildx build --platform "amd64,arm64" --tag "${TAG}" --output type=registry .
-
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@595be6a0f6560a0a8fc419ddf630567fc623531d # v0.22.0
-        with:
-          image-ref: '${{ vars.PUBLIC_REGISTRY }}/aks/aks-app-routing-operator:${{ inputs.version }}'
-          format: 'table'
-          exit-code: '1'
-          ignore-unfixed: true
-          vuln-type: 'os,library'
-          severity: 'CRITICAL,HIGH,MEDIUM'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
       TAG: aks-app-routing-operator-validate:${{ inputs.version }}
     steps:
       # validate image from sha input
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           ref: ${{ inputs.sha }}
       - name: Set up Docker Buildx
@@ -47,7 +47,7 @@ jobs:
     runs-on: ["self-hosted", "1ES.Pool=${{ vars.RUNNER_BASE_NAME }}-ubuntu"]
     steps:
       # always read the changelog in main
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           ref: 'main'
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,7 +28,7 @@ jobs:
         uses: docker/setup-buildx-action@16c0bc4a6e6ada2cfd8afd41d22d95379cf7c32a # v2.8.0
 
       - name: Build image locally
-        run: docker buildx build --tag "${TAG}" .
+        run: docker buildx build --tag "${TAG}" --load .
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@595be6a0f6560a0a8fc419ddf630567fc623531d # v0.22.0


### PR DESCRIPTION
# Description

blocks release workflow from running if trivy scan fails. Tested [here](https://github.com/OliverMKing/aks-app-routing/actions/runs/9586508229)