### PR TITLE
switch Dockerfiles to use mcr golang

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22 as builder
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.22 as builder
 
 WORKDIR /go/src/github.com/Azure/aks-app-routing-operator
 ADD . .

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -1,4 +1,4 @@
-FROM golang:1.22 as builder
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.22 as builder
 
 WORKDIR /go/src/e2e
 ADD . .

--- a/devenv/Dockerfile
+++ b/devenv/Dockerfile
@@ -1,6 +1,6 @@
 # convenience dockerfile for unit tests
 # run make unit from root
-FROM golang:1.22
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.22
 RUN mkdir -p /usr/local/kubebuilder/bin
 RUN wget -q https://github.com/etcd-io/etcd/releases/download/v3.5.0/etcd-v3.5.0-linux-amd64.tar.gz &&\
     tar xzf etcd-v3.5.0-linux-amd64.tar.gz &&\


### PR DESCRIPTION
# Description

switches our Dockerfiles to use mcr golang. Dockerhub rate limits which doesn't work with our GitHub workflows