### PR TITLE
Small fix for DnsZoneCountOne in basic e2e tests

### DIFF
--- a/testing/e2e/suites/basic.go
+++ b/testing/e2e/suites/basic.go
@@ -111,11 +111,11 @@ var clientServerTest = func(ctx context.Context, config *rest.Config, operator m
 	switch operator.Zones.Public {
 	case manifests.DnsZoneCountNone:
 	case manifests.DnsZoneCountOne:
-		zoners, err := toZoners(ctx, c, namespaces, infra.Zones[0])
+		zs, err := toZoners(ctx, c, namespaces, infra.Zones[0])
 		if err != nil {
 			return fmt.Errorf("converting to zoners: %w", err)
 		}
-		zoners = append(zoners, zoners...)
+		zoners = append(zoners, zs...)
 	case manifests.DnsZoneCountMultiple:
 		for _, z := range infra.Zones {
 			zs, err := toZoners(ctx, c, namespaces, z)
@@ -128,11 +128,11 @@ var clientServerTest = func(ctx context.Context, config *rest.Config, operator m
 	switch operator.Zones.Private {
 	case manifests.DnsZoneCountNone:
 	case manifests.DnsZoneCountOne:
-		zoners, err := toPrivateZoners(ctx, c, namespaces, infra.PrivateZones[0], infra.Cluster.GetDnsServiceIp())
+		zs, err := toPrivateZoners(ctx, c, namespaces, infra.PrivateZones[0], infra.Cluster.GetDnsServiceIp())
 		if err != nil {
 			return fmt.Errorf("converting to zoners: %w", err)
 		}
-		zoners = append(zoners, zoners...)
+		zoners = append(zoners, zs...)
 	case manifests.DnsZoneCountMultiple:
 		for _, z := range infra.PrivateZones {
 			zs, err := toPrivateZoners(ctx, c, namespaces, z, infra.Cluster.GetDnsServiceIp())


### PR DESCRIPTION
# Description
While testing other e2e tests I noticed that basic's tests did not create any zoners when using a single zone (DnsZoneCountOne) and thus skipped the test's logic and passed. Since it used DnsZoneCountOne instead of DnsZoneCountNone, the logic to catch a test that didn't have DNS zones also wasn't fired. Changing the variable name for the slice of zoners fixes the issues and the e2e tests for single zone tests still pass after testing. 

Fixes # (issue)
Feature # (details)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [X] Unit Tests
- [X] e2e tests


# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
