### PR TITLE
bump e2e vm count

### DIFF
--- a/testing/e2e/clients/aks.go
+++ b/testing/e2e/clients/aks.go
@@ -133,7 +133,7 @@ func NewAks(ctx context.Context, subscriptionId, resourceGroup, name, location s
 				{
 					Name:   to.Ptr("default"),
 					VMSize: to.Ptr("Standard_DS3_v2"),
-					Count:  to.Ptr(int32(4)),
+					Count:  to.Ptr(int32(5)),
 					Mode:   to.Ptr(armcontainerservice.AgentPoolModeSystem),
 				},
 			},


### PR DESCRIPTION
# Description

bumps e2e vm count. E2e sometimes runs out of node space on current setup.