### PR TITLE
Add aks managed by label to TopLevelLabels

### DIFF
--- a/pkg/manifests/common.go
+++ b/pkg/manifests/common.go
@@ -14,7 +14,7 @@ const operatorName = "aks-app-routing-operator"
 
 // GetTopLevelLabels returns labels that every resource App Routing manages have
 func GetTopLevelLabels() map[string]string { // this is a function to avoid any accidental mutation due to maps being reference types
-	return map[string]string{"app.kubernetes.io/managed-by": operatorName}
+	return map[string]string{"app.kubernetes.io/managed-by": operatorName, "kubernetes.azure.com/managedby": "aks"}
 }
 
 // HasTopLevelLabels returns true if the given labels match the top level labels

--- a/pkg/manifests/fixtures/external_dns/all-possibilities.yaml
+++ b/pkg/manifests/fixtures/external_dns/all-possibilities.yaml
@@ -15,6 +15,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: external-dns
+    kubernetes.azure.com/managedby: aks
   name: external-dns
   namespace: test-namespace
 ---
@@ -25,6 +26,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: external-dns
+    kubernetes.azure.com/managedby: aks
   name: external-dns
 rules:
 - apiGroups:
@@ -63,6 +65,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: external-dns
+    kubernetes.azure.com/managedby: aks
   name: external-dns
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -82,6 +85,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: external-dns
+    kubernetes.azure.com/managedby: aks
   name: external-dns
   namespace: test-namespace
 ---
@@ -92,6 +96,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: external-dns
+    kubernetes.azure.com/managedby: aks
   name: external-dns
   namespace: test-namespace
 spec:
@@ -108,6 +113,7 @@ spec:
         app: external-dns
         app.kubernetes.io/managed-by: aks-app-routing-operator
         checksum/configmap: 7a7768971308cadb
+        kubernetes.azure.com/managedby: aks
     spec:
       affinity:
         nodeAffinity:
@@ -202,6 +208,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: external-dns-private
+    kubernetes.azure.com/managedby: aks
   name: external-dns-private
   namespace: test-namespace
 ---
@@ -212,6 +219,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: external-dns-private
+    kubernetes.azure.com/managedby: aks
   name: external-dns-private
 rules:
 - apiGroups:
@@ -250,6 +258,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: external-dns-private
+    kubernetes.azure.com/managedby: aks
   name: external-dns-private
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -269,6 +278,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: external-dns-private
+    kubernetes.azure.com/managedby: aks
   name: external-dns-private
   namespace: test-namespace
 ---
@@ -279,6 +289,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: external-dns-private
+    kubernetes.azure.com/managedby: aks
   name: external-dns-private
   namespace: test-namespace
 spec:
@@ -295,6 +306,7 @@ spec:
         app: external-dns-private
         app.kubernetes.io/managed-by: aks-app-routing-operator
         checksum/configmap: aa75575c57a3fa54
+        kubernetes.azure.com/managedby: aks
     spec:
       affinity:
         nodeAffinity:
@@ -389,6 +401,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: test-dns-config-external-dns
+    kubernetes.azure.com/managedby: aks
   name: test-dns-config-external-dns
 rules:
 - apiGroups:
@@ -436,6 +449,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: test-dns-config-external-dns
+    kubernetes.azure.com/managedby: aks
   name: test-dns-config-external-dns
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -455,6 +469,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: test-dns-config-external-dns
+    kubernetes.azure.com/managedby: aks
   name: test-dns-config-external-dns
   namespace: test-namespace
 ---
@@ -465,6 +480,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: test-dns-config-external-dns
+    kubernetes.azure.com/managedby: aks
   name: test-dns-config-external-dns
   namespace: test-namespace
 spec:
@@ -481,6 +497,7 @@ spec:
         app: test-dns-config-external-dns
         app.kubernetes.io/managed-by: aks-app-routing-operator
         checksum/configmap: e363a30964578be3
+        kubernetes.azure.com/managedby: aks
     spec:
       affinity:
         nodeAffinity:
@@ -576,6 +593,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: test-dns-config-private-external-dns
+    kubernetes.azure.com/managedby: aks
   name: test-dns-config-private-external-dns
 rules:
 - apiGroups:
@@ -623,6 +641,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: test-dns-config-private-external-dns
+    kubernetes.azure.com/managedby: aks
   name: test-dns-config-private-external-dns
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -642,6 +661,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: test-dns-config-private-external-dns
+    kubernetes.azure.com/managedby: aks
   name: test-dns-config-private-external-dns
   namespace: test-namespace
 ---
@@ -652,6 +672,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: test-dns-config-private-external-dns
+    kubernetes.azure.com/managedby: aks
   name: test-dns-config-private-external-dns
   namespace: test-namespace
 spec:
@@ -668,6 +689,7 @@ spec:
         app: test-dns-config-private-external-dns
         app.kubernetes.io/managed-by: aks-app-routing-operator
         checksum/configmap: 10d3362c74fab97c
+        kubernetes.azure.com/managedby: aks
     spec:
       affinity:
         nodeAffinity:

--- a/pkg/manifests/fixtures/external_dns/full.yaml
+++ b/pkg/manifests/fixtures/external_dns/full.yaml
@@ -15,6 +15,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: external-dns
+    kubernetes.azure.com/managedby: aks
   name: external-dns
   namespace: test-namespace
 ---
@@ -25,6 +26,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: external-dns
+    kubernetes.azure.com/managedby: aks
   name: external-dns
 rules:
 - apiGroups:
@@ -63,6 +65,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: external-dns
+    kubernetes.azure.com/managedby: aks
   name: external-dns
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -82,6 +85,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: external-dns
+    kubernetes.azure.com/managedby: aks
   name: external-dns
   namespace: test-namespace
 ---
@@ -92,6 +96,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: external-dns
+    kubernetes.azure.com/managedby: aks
   name: external-dns
   namespace: test-namespace
 spec:
@@ -108,6 +113,7 @@ spec:
         app: external-dns
         app.kubernetes.io/managed-by: aks-app-routing-operator
         checksum/configmap: 7a7768971308cadb
+        kubernetes.azure.com/managedby: aks
     spec:
       affinity:
         nodeAffinity:
@@ -202,6 +208,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: external-dns-private
+    kubernetes.azure.com/managedby: aks
   name: external-dns-private
   namespace: test-namespace
 ---
@@ -212,6 +219,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: external-dns-private
+    kubernetes.azure.com/managedby: aks
   name: external-dns-private
 rules:
 - apiGroups:
@@ -250,6 +258,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: external-dns-private
+    kubernetes.azure.com/managedby: aks
   name: external-dns-private
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -269,6 +278,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: external-dns-private
+    kubernetes.azure.com/managedby: aks
   name: external-dns-private
   namespace: test-namespace
 ---
@@ -279,6 +289,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: external-dns-private
+    kubernetes.azure.com/managedby: aks
   name: external-dns-private
   namespace: test-namespace
 spec:
@@ -295,6 +306,7 @@ spec:
         app: external-dns-private
         app.kubernetes.io/managed-by: aks-app-routing-operator
         checksum/configmap: aa75575c57a3fa54
+        kubernetes.azure.com/managedby: aks
     spec:
       affinity:
         nodeAffinity:

--- a/pkg/manifests/fixtures/external_dns/no-ownership.yaml
+++ b/pkg/manifests/fixtures/external_dns/no-ownership.yaml
@@ -15,6 +15,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: external-dns
+    kubernetes.azure.com/managedby: aks
   name: external-dns
   namespace: test-namespace
 ---
@@ -25,6 +26,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: external-dns
+    kubernetes.azure.com/managedby: aks
   name: external-dns
 rules:
 - apiGroups:
@@ -63,6 +65,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: external-dns
+    kubernetes.azure.com/managedby: aks
   name: external-dns
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -82,6 +85,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: external-dns
+    kubernetes.azure.com/managedby: aks
   name: external-dns
   namespace: test-namespace
 ---
@@ -92,6 +96,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: external-dns
+    kubernetes.azure.com/managedby: aks
   name: external-dns
   namespace: test-namespace
 spec:
@@ -108,6 +113,7 @@ spec:
         app: external-dns
         app.kubernetes.io/managed-by: aks-app-routing-operator
         checksum/configmap: 7a7768971308cadb
+        kubernetes.azure.com/managedby: aks
     spec:
       affinity:
         nodeAffinity:

--- a/pkg/manifests/fixtures/external_dns/private-gateway.yaml
+++ b/pkg/manifests/fixtures/external_dns/private-gateway.yaml
@@ -15,6 +15,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: test-dns-config-private-external-dns
+    kubernetes.azure.com/managedby: aks
   name: test-dns-config-private-external-dns
 rules:
 - apiGroups:
@@ -62,6 +63,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: test-dns-config-private-external-dns
+    kubernetes.azure.com/managedby: aks
   name: test-dns-config-private-external-dns
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -81,6 +83,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: test-dns-config-private-external-dns
+    kubernetes.azure.com/managedby: aks
   name: test-dns-config-private-external-dns
   namespace: test-namespace
 ---
@@ -91,6 +94,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: test-dns-config-private-external-dns
+    kubernetes.azure.com/managedby: aks
   name: test-dns-config-private-external-dns
   namespace: test-namespace
 spec:
@@ -107,6 +111,7 @@ spec:
         app: test-dns-config-private-external-dns
         app.kubernetes.io/managed-by: aks-app-routing-operator
         checksum/configmap: 10d3362c74fab97c
+        kubernetes.azure.com/managedby: aks
     spec:
       affinity:
         nodeAffinity:

--- a/pkg/manifests/fixtures/external_dns/private-ingress-gateway.yaml
+++ b/pkg/manifests/fixtures/external_dns/private-ingress-gateway.yaml
@@ -15,6 +15,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: test-dns-config-private-external-dns
+    kubernetes.azure.com/managedby: aks
   name: test-dns-config-private-external-dns
 rules:
 - apiGroups:
@@ -71,6 +72,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: test-dns-config-private-external-dns
+    kubernetes.azure.com/managedby: aks
   name: test-dns-config-private-external-dns
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -90,6 +92,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: test-dns-config-private-external-dns
+    kubernetes.azure.com/managedby: aks
   name: test-dns-config-private-external-dns
   namespace: test-namespace
 ---
@@ -100,6 +103,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: test-dns-config-private-external-dns
+    kubernetes.azure.com/managedby: aks
   name: test-dns-config-private-external-dns
   namespace: test-namespace
 spec:
@@ -116,6 +120,7 @@ spec:
         app: test-dns-config-private-external-dns
         app.kubernetes.io/managed-by: aks-app-routing-operator
         checksum/configmap: 10d3362c74fab97c
+        kubernetes.azure.com/managedby: aks
     spec:
       affinity:
         nodeAffinity:

--- a/pkg/manifests/fixtures/external_dns/private.yaml
+++ b/pkg/manifests/fixtures/external_dns/private.yaml
@@ -15,6 +15,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: external-dns-private
+    kubernetes.azure.com/managedby: aks
   name: external-dns-private
   namespace: test-namespace
 ---
@@ -25,6 +26,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: external-dns-private
+    kubernetes.azure.com/managedby: aks
   name: external-dns-private
 rules:
 - apiGroups:
@@ -63,6 +65,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: external-dns-private
+    kubernetes.azure.com/managedby: aks
   name: external-dns-private
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -82,6 +85,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: external-dns-private
+    kubernetes.azure.com/managedby: aks
   name: external-dns-private
   namespace: test-namespace
 ---
@@ -92,6 +96,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: external-dns-private
+    kubernetes.azure.com/managedby: aks
   name: external-dns-private
   namespace: test-namespace
 spec:
@@ -108,6 +113,7 @@ spec:
         app: external-dns-private
         app.kubernetes.io/managed-by: aks-app-routing-operator
         checksum/configmap: aa75575c57a3fa54
+        kubernetes.azure.com/managedby: aks
     spec:
       affinity:
         nodeAffinity:

--- a/pkg/manifests/fixtures/external_dns/short-sync-interval.yaml
+++ b/pkg/manifests/fixtures/external_dns/short-sync-interval.yaml
@@ -15,6 +15,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: external-dns
+    kubernetes.azure.com/managedby: aks
   name: external-dns
   namespace: test-namespace
 ---
@@ -25,6 +26,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: external-dns
+    kubernetes.azure.com/managedby: aks
   name: external-dns
 rules:
 - apiGroups:
@@ -63,6 +65,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: external-dns
+    kubernetes.azure.com/managedby: aks
   name: external-dns
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -82,6 +85,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: external-dns
+    kubernetes.azure.com/managedby: aks
   name: external-dns
   namespace: test-namespace
 ---
@@ -92,6 +96,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: external-dns
+    kubernetes.azure.com/managedby: aks
   name: external-dns
   namespace: test-namespace
 spec:
@@ -108,6 +113,7 @@ spec:
         app: external-dns
         app.kubernetes.io/managed-by: aks-app-routing-operator
         checksum/configmap: 7a7768971308cadb
+        kubernetes.azure.com/managedby: aks
     spec:
       affinity:
         nodeAffinity:
@@ -202,6 +208,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: external-dns-private
+    kubernetes.azure.com/managedby: aks
   name: external-dns-private
   namespace: test-namespace
 ---
@@ -212,6 +219,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: external-dns-private
+    kubernetes.azure.com/managedby: aks
   name: external-dns-private
 rules:
 - apiGroups:
@@ -250,6 +258,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: external-dns-private
+    kubernetes.azure.com/managedby: aks
   name: external-dns-private
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -269,6 +278,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: external-dns-private
+    kubernetes.azure.com/managedby: aks
   name: external-dns-private
   namespace: test-namespace
 ---
@@ -279,6 +289,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: external-dns-private
+    kubernetes.azure.com/managedby: aks
   name: external-dns-private
   namespace: test-namespace
 spec:
@@ -295,6 +306,7 @@ spec:
         app: external-dns-private
         app.kubernetes.io/managed-by: aks-app-routing-operator
         checksum/configmap: aa75575c57a3fa54
+        kubernetes.azure.com/managedby: aks
     spec:
       affinity:
         nodeAffinity:

--- a/pkg/manifests/fixtures/nginx/default_version/full-with-replicas.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/full-with-replicas.yaml
@@ -15,6 +15,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: webapprouting.kubernetes.azure.com
 spec:
   controller: webapprouting.kubernetes.azure.com/nginx
@@ -27,6 +28,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -38,6 +40,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 rules:
 - apiGroups:
@@ -119,6 +122,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 rules:
@@ -214,6 +218,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -232,6 +237,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 roleRef:
@@ -253,6 +259,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -281,6 +288,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx-metrics
   namespace: test-namespace
 spec:
@@ -302,6 +310,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -321,6 +330,7 @@ spec:
         app: nginx
         app.kubernetes.io/component: ingress-controller
         app.kubernetes.io/managed-by: aks-app-routing-operator
+        kubernetes.azure.com/managedby: aks
     spec:
       affinity:
         nodeAffinity:
@@ -432,6 +442,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -443,6 +454,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -465,6 +477,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:

--- a/pkg/manifests/fixtures/nginx/default_version/full-with-target-cpu.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/full-with-target-cpu.yaml
@@ -15,6 +15,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: webapprouting.kubernetes.azure.com
 spec:
   controller: webapprouting.kubernetes.azure.com/nginx
@@ -27,6 +28,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -38,6 +40,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 rules:
 - apiGroups:
@@ -119,6 +122,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 rules:
@@ -214,6 +218,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -232,6 +237,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 roleRef:
@@ -253,6 +259,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -281,6 +288,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx-metrics
   namespace: test-namespace
 spec:
@@ -302,6 +310,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -321,6 +330,7 @@ spec:
         app: nginx
         app.kubernetes.io/component: ingress-controller
         app.kubernetes.io/managed-by: aks-app-routing-operator
+        kubernetes.azure.com/managedby: aks
     spec:
       affinity:
         nodeAffinity:
@@ -432,6 +442,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -443,6 +454,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -465,6 +477,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:

--- a/pkg/manifests/fixtures/nginx/default_version/full.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/full.yaml
@@ -15,6 +15,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: webapprouting.kubernetes.azure.com
 spec:
   controller: webapprouting.kubernetes.azure.com/nginx
@@ -27,6 +28,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -38,6 +40,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 rules:
 - apiGroups:
@@ -119,6 +122,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 rules:
@@ -214,6 +218,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -232,6 +237,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 roleRef:
@@ -253,6 +259,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -281,6 +288,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx-metrics
   namespace: test-namespace
 spec:
@@ -302,6 +310,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -321,6 +330,7 @@ spec:
         app: nginx
         app.kubernetes.io/component: ingress-controller
         app.kubernetes.io/managed-by: aks-app-routing-operator
+        kubernetes.azure.com/managedby: aks
     spec:
       affinity:
         nodeAffinity:
@@ -432,6 +442,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -443,6 +454,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -465,6 +477,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:

--- a/pkg/manifests/fixtures/nginx/default_version/internal-with-custom-http-errors-cert-and-service.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/internal-with-custom-http-errors-cert-and-service.yaml
@@ -15,6 +15,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx-private
 spec:
   controller: test-controller-class
@@ -27,6 +28,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -38,6 +40,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 rules:
 - apiGroups:
@@ -119,6 +122,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 rules:
@@ -214,6 +218,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -232,6 +237,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 roleRef:
@@ -251,6 +257,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -279,6 +286,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx-metrics
   namespace: test-namespace
 spec:
@@ -300,6 +308,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -319,6 +328,7 @@ spec:
         app: nginx
         app.kubernetes.io/component: ingress-controller
         app.kubernetes.io/managed-by: aks-app-routing-operator
+        kubernetes.azure.com/managedby: aks
     spec:
       affinity:
         nodeAffinity:
@@ -434,6 +444,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -445,6 +456,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -467,6 +479,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:

--- a/pkg/manifests/fixtures/nginx/default_version/internal-with-custom-http-errors.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/internal-with-custom-http-errors.yaml
@@ -15,6 +15,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx-private
 spec:
   controller: test-controller-class
@@ -27,6 +28,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -38,6 +40,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 rules:
 - apiGroups:
@@ -119,6 +122,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 rules:
@@ -214,6 +218,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -232,6 +237,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 roleRef:
@@ -251,6 +257,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -279,6 +286,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx-metrics
   namespace: test-namespace
 spec:
@@ -300,6 +308,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -319,6 +328,7 @@ spec:
         app: nginx
         app.kubernetes.io/component: ingress-controller
         app.kubernetes.io/managed-by: aks-app-routing-operator
+        kubernetes.azure.com/managedby: aks
     spec:
       affinity:
         nodeAffinity:
@@ -431,6 +441,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -442,6 +453,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -464,6 +476,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:

--- a/pkg/manifests/fixtures/nginx/default_version/internal-with-default-backend-service-and-ssl-cert.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/internal-with-default-backend-service-and-ssl-cert.yaml
@@ -15,6 +15,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx-private
 spec:
   controller: test-controller-class
@@ -27,6 +28,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -38,6 +40,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 rules:
 - apiGroups:
@@ -119,6 +122,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 rules:
@@ -214,6 +218,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -232,6 +237,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 roleRef:
@@ -251,6 +257,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -279,6 +286,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx-metrics
   namespace: test-namespace
 spec:
@@ -300,6 +308,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -319,6 +328,7 @@ spec:
         app: nginx
         app.kubernetes.io/component: ingress-controller
         app.kubernetes.io/managed-by: aks-app-routing-operator
+        kubernetes.azure.com/managedby: aks
     spec:
       affinity:
         nodeAffinity:
@@ -433,6 +443,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -444,6 +455,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -466,6 +478,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:

--- a/pkg/manifests/fixtures/nginx/default_version/internal-with-default-backend-service.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/internal-with-default-backend-service.yaml
@@ -15,6 +15,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx-private
 spec:
   controller: test-controller-class
@@ -27,6 +28,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -38,6 +40,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 rules:
 - apiGroups:
@@ -119,6 +122,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 rules:
@@ -214,6 +218,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -232,6 +237,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 roleRef:
@@ -251,6 +257,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -279,6 +286,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx-metrics
   namespace: test-namespace
 spec:
@@ -300,6 +308,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -319,6 +328,7 @@ spec:
         app: nginx
         app.kubernetes.io/component: ingress-controller
         app.kubernetes.io/managed-by: aks-app-routing-operator
+        kubernetes.azure.com/managedby: aks
     spec:
       affinity:
         nodeAffinity:
@@ -431,6 +441,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -442,6 +453,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -464,6 +476,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:

--- a/pkg/manifests/fixtures/nginx/default_version/internal-with-nil-ssl-cert-and-force-ssl.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/internal-with-nil-ssl-cert-and-force-ssl.yaml
@@ -15,6 +15,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx-private
 spec:
   controller: test-controller-class
@@ -27,6 +28,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -38,6 +40,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 rules:
 - apiGroups:
@@ -119,6 +122,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 rules:
@@ -214,6 +218,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -232,6 +237,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 roleRef:
@@ -251,6 +257,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -279,6 +286,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx-metrics
   namespace: test-namespace
 spec:
@@ -300,6 +308,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -319,6 +328,7 @@ spec:
         app: nginx
         app.kubernetes.io/component: ingress-controller
         app.kubernetes.io/managed-by: aks-app-routing-operator
+        kubernetes.azure.com/managedby: aks
     spec:
       affinity:
         nodeAffinity:
@@ -430,6 +440,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -441,6 +452,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -463,6 +475,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:

--- a/pkg/manifests/fixtures/nginx/default_version/internal-with-ssl-cert-and-force-ssl.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/internal-with-ssl-cert-and-force-ssl.yaml
@@ -15,6 +15,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx-private
 spec:
   controller: test-controller-class
@@ -27,6 +28,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -38,6 +40,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 rules:
 - apiGroups:
@@ -119,6 +122,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 rules:
@@ -214,6 +218,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -232,6 +237,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 roleRef:
@@ -251,6 +257,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -279,6 +286,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx-metrics
   namespace: test-namespace
 spec:
@@ -300,6 +308,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -319,6 +328,7 @@ spec:
         app: nginx
         app.kubernetes.io/component: ingress-controller
         app.kubernetes.io/managed-by: aks-app-routing-operator
+        kubernetes.azure.com/managedby: aks
     spec:
       affinity:
         nodeAffinity:
@@ -432,6 +442,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -443,6 +454,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -465,6 +477,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:

--- a/pkg/manifests/fixtures/nginx/default_version/internal-with-ssl-cert.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/internal-with-ssl-cert.yaml
@@ -15,6 +15,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx-private
 spec:
   controller: test-controller-class
@@ -27,6 +28,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -38,6 +40,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 rules:
 - apiGroups:
@@ -119,6 +122,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 rules:
@@ -214,6 +218,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -232,6 +237,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 roleRef:
@@ -251,6 +257,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -279,6 +286,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx-metrics
   namespace: test-namespace
 spec:
@@ -300,6 +308,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -319,6 +328,7 @@ spec:
         app: nginx
         app.kubernetes.io/component: ingress-controller
         app.kubernetes.io/managed-by: aks-app-routing-operator
+        kubernetes.azure.com/managedby: aks
     spec:
       affinity:
         nodeAffinity:
@@ -431,6 +441,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -442,6 +453,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -464,6 +476,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:

--- a/pkg/manifests/fixtures/nginx/default_version/internal.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/internal.yaml
@@ -15,6 +15,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx-private
 spec:
   controller: test-controller-class
@@ -27,6 +28,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -38,6 +40,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 rules:
 - apiGroups:
@@ -119,6 +122,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 rules:
@@ -214,6 +218,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -232,6 +237,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 roleRef:
@@ -251,6 +257,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -279,6 +286,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx-metrics
   namespace: test-namespace
 spec:
@@ -300,6 +308,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -319,6 +328,7 @@ spec:
         app: nginx
         app.kubernetes.io/component: ingress-controller
         app.kubernetes.io/managed-by: aks-app-routing-operator
+        kubernetes.azure.com/managedby: aks
     spec:
       affinity:
         nodeAffinity:
@@ -430,6 +440,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -441,6 +452,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -463,6 +475,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:

--- a/pkg/manifests/fixtures/nginx/default_version/kube-system.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/kube-system.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: webapprouting.kubernetes.azure.com
 spec:
   controller: webapprouting.kubernetes.azure.com/nginx
@@ -17,6 +18,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: kube-system
 ---
@@ -28,6 +30,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 rules:
 - apiGroups:
@@ -109,6 +112,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: kube-system
 rules:
@@ -204,6 +208,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -222,6 +227,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: kube-system
 roleRef:
@@ -243,6 +249,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: kube-system
 spec:
@@ -271,6 +278,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx-metrics
   namespace: kube-system
 spec:
@@ -292,6 +300,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: kube-system
 spec:
@@ -311,6 +320,7 @@ spec:
         app: nginx
         app.kubernetes.io/component: ingress-controller
         app.kubernetes.io/managed-by: aks-app-routing-operator
+        kubernetes.azure.com/managedby: aks
     spec:
       affinity:
         nodeAffinity:
@@ -422,6 +432,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: kube-system
 ---
@@ -433,6 +444,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: kube-system
 spec:
@@ -455,6 +467,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: kube-system
 spec:

--- a/pkg/manifests/fixtures/nginx/default_version/no-ownership.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/no-ownership.yaml
@@ -15,6 +15,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: webapprouting.kubernetes.azure.com
 spec:
   controller: webapprouting.kubernetes.azure.com/nginx
@@ -27,6 +28,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -38,6 +40,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 rules:
 - apiGroups:
@@ -119,6 +122,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 rules:
@@ -214,6 +218,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -232,6 +237,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 roleRef:
@@ -253,6 +259,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -281,6 +288,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx-metrics
   namespace: test-namespace
 spec:
@@ -302,6 +310,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -321,6 +330,7 @@ spec:
         app: nginx
         app.kubernetes.io/component: ingress-controller
         app.kubernetes.io/managed-by: aks-app-routing-operator
+        kubernetes.azure.com/managedby: aks
     spec:
       affinity:
         nodeAffinity:
@@ -432,6 +442,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -443,6 +454,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -465,6 +477,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:

--- a/pkg/manifests/fixtures/nginx/default_version/optional-features-disabled.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/optional-features-disabled.yaml
@@ -13,6 +13,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: webapprouting.kubernetes.azure.com
 spec:
   controller: webapprouting.kubernetes.azure.com/nginx
@@ -25,6 +26,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -36,6 +38,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 rules:
 - apiGroups:
@@ -117,6 +120,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 rules:
@@ -212,6 +216,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -230,6 +235,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 roleRef:
@@ -251,6 +257,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -279,6 +286,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx-metrics
   namespace: test-namespace
 spec:
@@ -300,6 +308,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -318,6 +327,7 @@ spec:
         app: nginx
         app.kubernetes.io/component: ingress-controller
         app.kubernetes.io/managed-by: aks-app-routing-operator
+        kubernetes.azure.com/managedby: aks
     spec:
       affinity:
         nodeAffinity:
@@ -429,6 +439,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -440,6 +451,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -462,6 +474,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:

--- a/pkg/manifests/fixtures/nginx/v1.10.0/full-with-replicas.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.10.0/full-with-replicas.yaml
@@ -15,6 +15,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: webapprouting.kubernetes.azure.com
 spec:
   controller: webapprouting.kubernetes.azure.com/nginx
@@ -27,6 +28,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -38,6 +40,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 rules:
 - apiGroups:
@@ -119,6 +122,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 rules:
@@ -214,6 +218,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -232,6 +237,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 roleRef:
@@ -255,6 +261,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -283,6 +290,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -302,6 +310,7 @@ spec:
         app: nginx
         app.kubernetes.io/component: ingress-controller
         app.kubernetes.io/managed-by: aks-app-routing-operator
+        kubernetes.azure.com/managedby: aks
     spec:
       affinity:
         nodeAffinity:
@@ -413,6 +422,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -424,6 +434,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -446,6 +457,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:

--- a/pkg/manifests/fixtures/nginx/v1.10.0/full-with-target-cpu.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.10.0/full-with-target-cpu.yaml
@@ -15,6 +15,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: webapprouting.kubernetes.azure.com
 spec:
   controller: webapprouting.kubernetes.azure.com/nginx
@@ -27,6 +28,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -38,6 +40,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 rules:
 - apiGroups:
@@ -119,6 +122,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 rules:
@@ -214,6 +218,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -232,6 +237,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 roleRef:
@@ -255,6 +261,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -283,6 +290,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -302,6 +310,7 @@ spec:
         app: nginx
         app.kubernetes.io/component: ingress-controller
         app.kubernetes.io/managed-by: aks-app-routing-operator
+        kubernetes.azure.com/managedby: aks
     spec:
       affinity:
         nodeAffinity:
@@ -413,6 +422,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -424,6 +434,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -446,6 +457,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:

--- a/pkg/manifests/fixtures/nginx/v1.10.0/full.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.10.0/full.yaml
@@ -15,6 +15,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: webapprouting.kubernetes.azure.com
 spec:
   controller: webapprouting.kubernetes.azure.com/nginx
@@ -27,6 +28,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -38,6 +40,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 rules:
 - apiGroups:
@@ -119,6 +122,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 rules:
@@ -214,6 +218,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -232,6 +237,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 roleRef:
@@ -255,6 +261,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -283,6 +290,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -302,6 +310,7 @@ spec:
         app: nginx
         app.kubernetes.io/component: ingress-controller
         app.kubernetes.io/managed-by: aks-app-routing-operator
+        kubernetes.azure.com/managedby: aks
     spec:
       affinity:
         nodeAffinity:
@@ -413,6 +422,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -424,6 +434,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -446,6 +457,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:

--- a/pkg/manifests/fixtures/nginx/v1.10.0/internal-with-custom-http-errors-cert-and-service.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.10.0/internal-with-custom-http-errors-cert-and-service.yaml
@@ -15,6 +15,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx-private
 spec:
   controller: test-controller-class
@@ -27,6 +28,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -38,6 +40,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 rules:
 - apiGroups:
@@ -119,6 +122,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 rules:
@@ -214,6 +218,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -232,6 +237,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 roleRef:
@@ -254,6 +260,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -282,6 +289,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -301,6 +309,7 @@ spec:
         app: nginx
         app.kubernetes.io/component: ingress-controller
         app.kubernetes.io/managed-by: aks-app-routing-operator
+        kubernetes.azure.com/managedby: aks
     spec:
       affinity:
         nodeAffinity:
@@ -414,6 +423,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -425,6 +435,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -447,6 +458,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:

--- a/pkg/manifests/fixtures/nginx/v1.10.0/internal-with-custom-http-errors.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.10.0/internal-with-custom-http-errors.yaml
@@ -15,6 +15,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx-private
 spec:
   controller: test-controller-class
@@ -27,6 +28,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -38,6 +40,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 rules:
 - apiGroups:
@@ -119,6 +122,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 rules:
@@ -214,6 +218,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -232,6 +237,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 roleRef:
@@ -254,6 +260,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -282,6 +289,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -301,6 +309,7 @@ spec:
         app: nginx
         app.kubernetes.io/component: ingress-controller
         app.kubernetes.io/managed-by: aks-app-routing-operator
+        kubernetes.azure.com/managedby: aks
     spec:
       affinity:
         nodeAffinity:
@@ -412,6 +421,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -423,6 +433,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -445,6 +456,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:

--- a/pkg/manifests/fixtures/nginx/v1.10.0/internal-with-default-backend-service-and-ssl-cert.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.10.0/internal-with-default-backend-service-and-ssl-cert.yaml
@@ -15,6 +15,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx-private
 spec:
   controller: test-controller-class
@@ -27,6 +28,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -38,6 +40,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 rules:
 - apiGroups:
@@ -119,6 +122,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 rules:
@@ -214,6 +218,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -232,6 +237,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 roleRef:
@@ -254,6 +260,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -282,6 +289,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -301,6 +309,7 @@ spec:
         app: nginx
         app.kubernetes.io/component: ingress-controller
         app.kubernetes.io/managed-by: aks-app-routing-operator
+        kubernetes.azure.com/managedby: aks
     spec:
       affinity:
         nodeAffinity:
@@ -415,6 +424,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -426,6 +436,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -448,6 +459,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:

--- a/pkg/manifests/fixtures/nginx/v1.10.0/internal-with-default-backend-service.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.10.0/internal-with-default-backend-service.yaml
@@ -15,6 +15,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx-private
 spec:
   controller: test-controller-class
@@ -27,6 +28,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -38,6 +40,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 rules:
 - apiGroups:
@@ -119,6 +122,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 rules:
@@ -214,6 +218,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -232,6 +237,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 roleRef:
@@ -254,6 +260,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -282,6 +289,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -301,6 +309,7 @@ spec:
         app: nginx
         app.kubernetes.io/component: ingress-controller
         app.kubernetes.io/managed-by: aks-app-routing-operator
+        kubernetes.azure.com/managedby: aks
     spec:
       affinity:
         nodeAffinity:
@@ -413,6 +422,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -424,6 +434,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -446,6 +457,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:

--- a/pkg/manifests/fixtures/nginx/v1.10.0/internal-with-nil-ssl-cert-and-force-ssl.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.10.0/internal-with-nil-ssl-cert-and-force-ssl.yaml
@@ -15,6 +15,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx-private
 spec:
   controller: test-controller-class
@@ -27,6 +28,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -38,6 +40,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 rules:
 - apiGroups:
@@ -119,6 +122,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 rules:
@@ -214,6 +218,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -232,6 +237,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 roleRef:
@@ -254,6 +260,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -282,6 +289,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -301,6 +309,7 @@ spec:
         app: nginx
         app.kubernetes.io/component: ingress-controller
         app.kubernetes.io/managed-by: aks-app-routing-operator
+        kubernetes.azure.com/managedby: aks
     spec:
       affinity:
         nodeAffinity:
@@ -412,6 +421,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -423,6 +433,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -445,6 +456,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:

--- a/pkg/manifests/fixtures/nginx/v1.10.0/internal-with-ssl-cert-and-force-ssl.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.10.0/internal-with-ssl-cert-and-force-ssl.yaml
@@ -15,6 +15,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx-private
 spec:
   controller: test-controller-class
@@ -27,6 +28,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -38,6 +40,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 rules:
 - apiGroups:
@@ -119,6 +122,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 rules:
@@ -214,6 +218,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -232,6 +237,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 roleRef:
@@ -254,6 +260,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -282,6 +289,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -301,6 +309,7 @@ spec:
         app: nginx
         app.kubernetes.io/component: ingress-controller
         app.kubernetes.io/managed-by: aks-app-routing-operator
+        kubernetes.azure.com/managedby: aks
     spec:
       affinity:
         nodeAffinity:
@@ -414,6 +423,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -425,6 +435,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -447,6 +458,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:

--- a/pkg/manifests/fixtures/nginx/v1.10.0/internal-with-ssl-cert.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.10.0/internal-with-ssl-cert.yaml
@@ -15,6 +15,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx-private
 spec:
   controller: test-controller-class
@@ -27,6 +28,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -38,6 +40,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 rules:
 - apiGroups:
@@ -119,6 +122,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 rules:
@@ -214,6 +218,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -232,6 +237,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 roleRef:
@@ -254,6 +260,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -282,6 +289,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -301,6 +309,7 @@ spec:
         app: nginx
         app.kubernetes.io/component: ingress-controller
         app.kubernetes.io/managed-by: aks-app-routing-operator
+        kubernetes.azure.com/managedby: aks
     spec:
       affinity:
         nodeAffinity:
@@ -413,6 +422,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -424,6 +434,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -446,6 +457,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:

--- a/pkg/manifests/fixtures/nginx/v1.10.0/internal.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.10.0/internal.yaml
@@ -15,6 +15,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx-private
 spec:
   controller: test-controller-class
@@ -27,6 +28,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -38,6 +40,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 rules:
 - apiGroups:
@@ -119,6 +122,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 rules:
@@ -214,6 +218,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -232,6 +237,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 roleRef:
@@ -254,6 +260,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -282,6 +289,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -301,6 +309,7 @@ spec:
         app: nginx
         app.kubernetes.io/component: ingress-controller
         app.kubernetes.io/managed-by: aks-app-routing-operator
+        kubernetes.azure.com/managedby: aks
     spec:
       affinity:
         nodeAffinity:
@@ -412,6 +421,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -423,6 +433,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -445,6 +456,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:

--- a/pkg/manifests/fixtures/nginx/v1.10.0/kube-system.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.10.0/kube-system.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: webapprouting.kubernetes.azure.com
 spec:
   controller: webapprouting.kubernetes.azure.com/nginx
@@ -17,6 +18,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: kube-system
 ---
@@ -28,6 +30,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 rules:
 - apiGroups:
@@ -109,6 +112,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: kube-system
 rules:
@@ -204,6 +208,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -222,6 +227,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: kube-system
 roleRef:
@@ -245,6 +251,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: kube-system
 spec:
@@ -273,6 +280,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: kube-system
 spec:
@@ -292,6 +300,7 @@ spec:
         app: nginx
         app.kubernetes.io/component: ingress-controller
         app.kubernetes.io/managed-by: aks-app-routing-operator
+        kubernetes.azure.com/managedby: aks
     spec:
       affinity:
         nodeAffinity:
@@ -403,6 +412,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: kube-system
 ---
@@ -414,6 +424,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: kube-system
 spec:
@@ -436,6 +447,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: kube-system
 spec:

--- a/pkg/manifests/fixtures/nginx/v1.10.0/no-ownership.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.10.0/no-ownership.yaml
@@ -15,6 +15,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: webapprouting.kubernetes.azure.com
 spec:
   controller: webapprouting.kubernetes.azure.com/nginx
@@ -27,6 +28,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -38,6 +40,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 rules:
 - apiGroups:
@@ -119,6 +122,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 rules:
@@ -214,6 +218,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -232,6 +237,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 roleRef:
@@ -255,6 +261,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -283,6 +290,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -302,6 +310,7 @@ spec:
         app: nginx
         app.kubernetes.io/component: ingress-controller
         app.kubernetes.io/managed-by: aks-app-routing-operator
+        kubernetes.azure.com/managedby: aks
     spec:
       affinity:
         nodeAffinity:
@@ -413,6 +422,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -424,6 +434,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -446,6 +457,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:

--- a/pkg/manifests/fixtures/nginx/v1.10.0/optional-features-disabled.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.10.0/optional-features-disabled.yaml
@@ -13,6 +13,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: webapprouting.kubernetes.azure.com
 spec:
   controller: webapprouting.kubernetes.azure.com/nginx
@@ -25,6 +26,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -36,6 +38,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 rules:
 - apiGroups:
@@ -117,6 +120,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 rules:
@@ -212,6 +216,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -230,6 +235,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 roleRef:
@@ -253,6 +259,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -281,6 +288,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -299,6 +307,7 @@ spec:
         app: nginx
         app.kubernetes.io/component: ingress-controller
         app.kubernetes.io/managed-by: aks-app-routing-operator
+        kubernetes.azure.com/managedby: aks
     spec:
       affinity:
         nodeAffinity:
@@ -410,6 +419,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -421,6 +431,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -443,6 +454,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:

--- a/pkg/manifests/fixtures/nginx/v1.11.2/full-with-replicas.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.11.2/full-with-replicas.yaml
@@ -15,6 +15,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: webapprouting.kubernetes.azure.com
 spec:
   controller: webapprouting.kubernetes.azure.com/nginx
@@ -27,6 +28,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -38,6 +40,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 rules:
 - apiGroups:
@@ -119,6 +122,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 rules:
@@ -214,6 +218,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -232,6 +237,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 roleRef:
@@ -253,6 +259,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -281,6 +288,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx-metrics
   namespace: test-namespace
 spec:
@@ -302,6 +310,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -321,6 +330,7 @@ spec:
         app: nginx
         app.kubernetes.io/component: ingress-controller
         app.kubernetes.io/managed-by: aks-app-routing-operator
+        kubernetes.azure.com/managedby: aks
     spec:
       affinity:
         nodeAffinity:
@@ -432,6 +442,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -443,6 +454,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -465,6 +477,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:

--- a/pkg/manifests/fixtures/nginx/v1.11.2/full-with-target-cpu.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.11.2/full-with-target-cpu.yaml
@@ -15,6 +15,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: webapprouting.kubernetes.azure.com
 spec:
   controller: webapprouting.kubernetes.azure.com/nginx
@@ -27,6 +28,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -38,6 +40,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 rules:
 - apiGroups:
@@ -119,6 +122,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 rules:
@@ -214,6 +218,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -232,6 +237,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 roleRef:
@@ -253,6 +259,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -281,6 +288,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx-metrics
   namespace: test-namespace
 spec:
@@ -302,6 +310,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -321,6 +330,7 @@ spec:
         app: nginx
         app.kubernetes.io/component: ingress-controller
         app.kubernetes.io/managed-by: aks-app-routing-operator
+        kubernetes.azure.com/managedby: aks
     spec:
       affinity:
         nodeAffinity:
@@ -432,6 +442,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -443,6 +454,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -465,6 +477,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:

--- a/pkg/manifests/fixtures/nginx/v1.11.2/full.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.11.2/full.yaml
@@ -15,6 +15,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: webapprouting.kubernetes.azure.com
 spec:
   controller: webapprouting.kubernetes.azure.com/nginx
@@ -27,6 +28,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -38,6 +40,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 rules:
 - apiGroups:
@@ -119,6 +122,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 rules:
@@ -214,6 +218,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -232,6 +237,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 roleRef:
@@ -253,6 +259,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -281,6 +288,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx-metrics
   namespace: test-namespace
 spec:
@@ -302,6 +310,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -321,6 +330,7 @@ spec:
         app: nginx
         app.kubernetes.io/component: ingress-controller
         app.kubernetes.io/managed-by: aks-app-routing-operator
+        kubernetes.azure.com/managedby: aks
     spec:
       affinity:
         nodeAffinity:
@@ -432,6 +442,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -443,6 +454,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -465,6 +477,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:

--- a/pkg/manifests/fixtures/nginx/v1.11.2/internal-with-custom-http-errors-cert-and-service.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.11.2/internal-with-custom-http-errors-cert-and-service.yaml
@@ -15,6 +15,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx-private
 spec:
   controller: test-controller-class
@@ -27,6 +28,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -38,6 +40,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 rules:
 - apiGroups:
@@ -119,6 +122,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 rules:
@@ -214,6 +218,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -232,6 +237,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 roleRef:
@@ -251,6 +257,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -279,6 +286,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx-metrics
   namespace: test-namespace
 spec:
@@ -300,6 +308,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -319,6 +328,7 @@ spec:
         app: nginx
         app.kubernetes.io/component: ingress-controller
         app.kubernetes.io/managed-by: aks-app-routing-operator
+        kubernetes.azure.com/managedby: aks
     spec:
       affinity:
         nodeAffinity:
@@ -434,6 +444,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -445,6 +456,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -467,6 +479,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:

--- a/pkg/manifests/fixtures/nginx/v1.11.2/internal-with-custom-http-errors.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.11.2/internal-with-custom-http-errors.yaml
@@ -15,6 +15,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx-private
 spec:
   controller: test-controller-class
@@ -27,6 +28,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -38,6 +40,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 rules:
 - apiGroups:
@@ -119,6 +122,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 rules:
@@ -214,6 +218,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -232,6 +237,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 roleRef:
@@ -251,6 +257,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -279,6 +286,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx-metrics
   namespace: test-namespace
 spec:
@@ -300,6 +308,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -319,6 +328,7 @@ spec:
         app: nginx
         app.kubernetes.io/component: ingress-controller
         app.kubernetes.io/managed-by: aks-app-routing-operator
+        kubernetes.azure.com/managedby: aks
     spec:
       affinity:
         nodeAffinity:
@@ -431,6 +441,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -442,6 +453,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -464,6 +476,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:

--- a/pkg/manifests/fixtures/nginx/v1.11.2/internal-with-default-backend-service-and-ssl-cert.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.11.2/internal-with-default-backend-service-and-ssl-cert.yaml
@@ -15,6 +15,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx-private
 spec:
   controller: test-controller-class
@@ -27,6 +28,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -38,6 +40,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 rules:
 - apiGroups:
@@ -119,6 +122,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 rules:
@@ -214,6 +218,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -232,6 +237,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 roleRef:
@@ -251,6 +257,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -279,6 +286,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx-metrics
   namespace: test-namespace
 spec:
@@ -300,6 +308,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -319,6 +328,7 @@ spec:
         app: nginx
         app.kubernetes.io/component: ingress-controller
         app.kubernetes.io/managed-by: aks-app-routing-operator
+        kubernetes.azure.com/managedby: aks
     spec:
       affinity:
         nodeAffinity:
@@ -433,6 +443,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -444,6 +455,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -466,6 +478,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:

--- a/pkg/manifests/fixtures/nginx/v1.11.2/internal-with-default-backend-service.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.11.2/internal-with-default-backend-service.yaml
@@ -15,6 +15,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx-private
 spec:
   controller: test-controller-class
@@ -27,6 +28,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -38,6 +40,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 rules:
 - apiGroups:
@@ -119,6 +122,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 rules:
@@ -214,6 +218,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -232,6 +237,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 roleRef:
@@ -251,6 +257,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -279,6 +286,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx-metrics
   namespace: test-namespace
 spec:
@@ -300,6 +308,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -319,6 +328,7 @@ spec:
         app: nginx
         app.kubernetes.io/component: ingress-controller
         app.kubernetes.io/managed-by: aks-app-routing-operator
+        kubernetes.azure.com/managedby: aks
     spec:
       affinity:
         nodeAffinity:
@@ -431,6 +441,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -442,6 +453,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -464,6 +476,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:

--- a/pkg/manifests/fixtures/nginx/v1.11.2/internal-with-nil-ssl-cert-and-force-ssl.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.11.2/internal-with-nil-ssl-cert-and-force-ssl.yaml
@@ -15,6 +15,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx-private
 spec:
   controller: test-controller-class
@@ -27,6 +28,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -38,6 +40,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 rules:
 - apiGroups:
@@ -119,6 +122,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 rules:
@@ -214,6 +218,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -232,6 +237,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 roleRef:
@@ -251,6 +257,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -279,6 +286,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx-metrics
   namespace: test-namespace
 spec:
@@ -300,6 +308,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -319,6 +328,7 @@ spec:
         app: nginx
         app.kubernetes.io/component: ingress-controller
         app.kubernetes.io/managed-by: aks-app-routing-operator
+        kubernetes.azure.com/managedby: aks
     spec:
       affinity:
         nodeAffinity:
@@ -430,6 +440,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -441,6 +452,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -463,6 +475,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:

--- a/pkg/manifests/fixtures/nginx/v1.11.2/internal-with-ssl-cert-and-force-ssl.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.11.2/internal-with-ssl-cert-and-force-ssl.yaml
@@ -15,6 +15,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx-private
 spec:
   controller: test-controller-class
@@ -27,6 +28,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -38,6 +40,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 rules:
 - apiGroups:
@@ -119,6 +122,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 rules:
@@ -214,6 +218,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -232,6 +237,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 roleRef:
@@ -251,6 +257,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -279,6 +286,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx-metrics
   namespace: test-namespace
 spec:
@@ -300,6 +308,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -319,6 +328,7 @@ spec:
         app: nginx
         app.kubernetes.io/component: ingress-controller
         app.kubernetes.io/managed-by: aks-app-routing-operator
+        kubernetes.azure.com/managedby: aks
     spec:
       affinity:
         nodeAffinity:
@@ -432,6 +442,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -443,6 +454,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -465,6 +477,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:

--- a/pkg/manifests/fixtures/nginx/v1.11.2/internal-with-ssl-cert.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.11.2/internal-with-ssl-cert.yaml
@@ -15,6 +15,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx-private
 spec:
   controller: test-controller-class
@@ -27,6 +28,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -38,6 +40,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 rules:
 - apiGroups:
@@ -119,6 +122,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 rules:
@@ -214,6 +218,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -232,6 +237,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 roleRef:
@@ -251,6 +257,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -279,6 +286,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx-metrics
   namespace: test-namespace
 spec:
@@ -300,6 +308,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -319,6 +328,7 @@ spec:
         app: nginx
         app.kubernetes.io/component: ingress-controller
         app.kubernetes.io/managed-by: aks-app-routing-operator
+        kubernetes.azure.com/managedby: aks
     spec:
       affinity:
         nodeAffinity:
@@ -431,6 +441,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -442,6 +453,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -464,6 +476,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:

--- a/pkg/manifests/fixtures/nginx/v1.11.2/internal.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.11.2/internal.yaml
@@ -15,6 +15,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx-private
 spec:
   controller: test-controller-class
@@ -27,6 +28,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -38,6 +40,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 rules:
 - apiGroups:
@@ -119,6 +122,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 rules:
@@ -214,6 +218,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -232,6 +237,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 roleRef:
@@ -251,6 +257,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -279,6 +286,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx-metrics
   namespace: test-namespace
 spec:
@@ -300,6 +308,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -319,6 +328,7 @@ spec:
         app: nginx
         app.kubernetes.io/component: ingress-controller
         app.kubernetes.io/managed-by: aks-app-routing-operator
+        kubernetes.azure.com/managedby: aks
     spec:
       affinity:
         nodeAffinity:
@@ -430,6 +440,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -441,6 +452,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -463,6 +475,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:

--- a/pkg/manifests/fixtures/nginx/v1.11.2/kube-system.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.11.2/kube-system.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: webapprouting.kubernetes.azure.com
 spec:
   controller: webapprouting.kubernetes.azure.com/nginx
@@ -17,6 +18,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: kube-system
 ---
@@ -28,6 +30,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 rules:
 - apiGroups:
@@ -109,6 +112,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: kube-system
 rules:
@@ -204,6 +208,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -222,6 +227,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: kube-system
 roleRef:
@@ -243,6 +249,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: kube-system
 spec:
@@ -271,6 +278,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx-metrics
   namespace: kube-system
 spec:
@@ -292,6 +300,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: kube-system
 spec:
@@ -311,6 +320,7 @@ spec:
         app: nginx
         app.kubernetes.io/component: ingress-controller
         app.kubernetes.io/managed-by: aks-app-routing-operator
+        kubernetes.azure.com/managedby: aks
     spec:
       affinity:
         nodeAffinity:
@@ -422,6 +432,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: kube-system
 ---
@@ -433,6 +444,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: kube-system
 spec:
@@ -455,6 +467,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: kube-system
 spec:

--- a/pkg/manifests/fixtures/nginx/v1.11.2/no-ownership.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.11.2/no-ownership.yaml
@@ -15,6 +15,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: webapprouting.kubernetes.azure.com
 spec:
   controller: webapprouting.kubernetes.azure.com/nginx
@@ -27,6 +28,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -38,6 +40,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 rules:
 - apiGroups:
@@ -119,6 +122,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 rules:
@@ -214,6 +218,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -232,6 +237,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 roleRef:
@@ -253,6 +259,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -281,6 +288,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx-metrics
   namespace: test-namespace
 spec:
@@ -302,6 +310,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -321,6 +330,7 @@ spec:
         app: nginx
         app.kubernetes.io/component: ingress-controller
         app.kubernetes.io/managed-by: aks-app-routing-operator
+        kubernetes.azure.com/managedby: aks
     spec:
       affinity:
         nodeAffinity:
@@ -432,6 +442,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -443,6 +454,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -465,6 +477,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:

--- a/pkg/manifests/fixtures/nginx/v1.11.2/optional-features-disabled.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.11.2/optional-features-disabled.yaml
@@ -13,6 +13,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: webapprouting.kubernetes.azure.com
 spec:
   controller: webapprouting.kubernetes.azure.com/nginx
@@ -25,6 +26,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -36,6 +38,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 rules:
 - apiGroups:
@@ -117,6 +120,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 rules:
@@ -212,6 +216,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -230,6 +235,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 roleRef:
@@ -251,6 +257,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -279,6 +286,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx-metrics
   namespace: test-namespace
 spec:
@@ -300,6 +308,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -318,6 +327,7 @@ spec:
         app: nginx
         app.kubernetes.io/component: ingress-controller
         app.kubernetes.io/managed-by: aks-app-routing-operator
+        kubernetes.azure.com/managedby: aks
     spec:
       affinity:
         nodeAffinity:
@@ -429,6 +439,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 ---
@@ -440,6 +451,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:
@@ -462,6 +474,7 @@ metadata:
     app.kubernetes.io/component: ingress-controller
     app.kubernetes.io/managed-by: aks-app-routing-operator
     app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
   name: nginx
   namespace: test-namespace
 spec:


### PR DESCRIPTION
# Description

This adds the kubernetes.azure.com/managedby=aks lebel in the top level labels

## Type of change

Please delete options that are not relevant.

- [x] Observability

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Is it a breaking change which will impact consuming tool(s)?

- [x] UnitTests


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
