### PR TITLE
add coverage ignore mechanism for unit testing coverage report

### DIFF
--- a/.covignore
+++ b/.covignore
@@ -1,0 +1,1 @@
+github.com/Azure/aks-app-routing-operator/testing/

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -48,7 +48,10 @@ jobs:
         sudo mv kube-apiserver /usr/local/kubebuilder/bin/
 
     - name: Run Unit Tests
-      run: go test -race -v ./... -coverprofile=coverage.out
+      run: go test -race -v ./... -coverprofile=unfiltered.coverage.out
+
+    - name: Filter out coverage files
+      run: grep -v -E -f .covignore unfiltered.coverage.out > coverage.out
 
     - name: Convert coverage to lcov
       uses: jandelgado/gcov2lcov-action@c680c0f7c7442485f1749eb2a13e54a686e76eb5 #v1.0.8

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -53,14 +53,12 @@ jobs:
     - name: Filter out coverage files
       run: grep -v -E -f .covignore unfiltered.coverage.out > coverage.out
 
-    - name: Convert coverage to lcov
-      uses: jandelgado/gcov2lcov-action@c680c0f7c7442485f1749eb2a13e54a686e76eb5 #v1.0.8
-
     - name: Coveralls
-      uses: coverallsapp/github-action@95b1a2355bd0e526ad2fd62da9fd386ad4c98474 #v2.2.1
+      uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b #v2.3.6
       with:
         flag-name: unit-test
-        path-to-lcov: coverage.lcov
+        path-to-lcov: coverage.out
+        format: golang
         git-commit: ${{ inputs.status_ref }}
 
     - if: always()

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -1,0 +1,7 @@
+# Coverage
+
+Our PR gates include coverage tests ensuring that coverage is above a certain percentage.
+
+Not everything is unit testable so we have a mechanism for excluding files. This should be used extremely sparingly, most code is unit testable and if something isn't think about how it could be refactored to be better tested.
+
+To add a file or directory to be excluded simply append its Go representation to [.covignore](../.covignore).


### PR DESCRIPTION
# Description

add a mechanism for ignoring coverage to this repo. Only ignores our e2e tests for now. Will do an audit and split out some other stuff later so our coverage report is accurate.