### PR TITLE
add is active check to watchdog before erroring

### DIFF
--- a/pkg/controller/ingress/concurrency_watchdog.go
+++ b/pkg/controller/ingress/concurrency_watchdog.go
@@ -20,6 +20,7 @@ import (
 	"github.com/prometheus/common/expfmt"
 	corev1 "k8s.io/api/core/v1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -210,7 +211,7 @@ func (c *ConcurrencyWatchdog) tick(ctx context.Context) error {
 		nReadyPods := 0
 		var totalConnectionCount float64
 		for i, pod := range list.Items {
-			lgr := lgr.WithValues("pod", pod.Name)
+			lgr := lgr.WithValues("pod", pod.Name, "namespace", pod.Namespace)
 			if !podIsReady(&pod) {
 				lgr.Info("pod is not ready", "name", pod.Name)
 				continue
@@ -219,7 +220,16 @@ func (c *ConcurrencyWatchdog) tick(ctx context.Context) error {
 			ctx := logr.NewContext(ctx, lgr)
 			count, err := target.ScrapeFn(ctx, c.restClient, &pod)
 			if err != nil {
-				lgr.Error(err, "scraping pod", "name", pod.Name)
+
+				// check if pod is still ready. Pod might have become unready after checking it (this solves a race condition).
+				// we ignore an error on the podIsActive call, we want the retErr to be the error from scrapping not from checking if
+				// the pod is active.
+				if active, err := podIsActive(ctx, lgr, c.client, client.ObjectKeyFromObject(&pod)); err == nil && !active {
+					lgr.Info("pod isn't active anymore")
+					continue
+				}
+
+				lgr.Error(err, "scraping pod")
 				retErr = multierror.Append(retErr, fmt.Errorf("scraping pod %q: %w", pod.Name, err))
 				continue
 			}
@@ -335,4 +345,24 @@ func podIsReady(pod *corev1.Pod) bool {
 		}
 	}
 	return false
+}
+
+// podIsActive checks if a Pod is Ready and exists and is able to serve connections
+func podIsActive(ctx context.Context, lgr logr.Logger, cl client.Client, pod client.ObjectKey) (bool, error) {
+	var obj corev1.Pod
+	err := cl.Get(ctx, pod, &obj)
+	if apierrors.IsNotFound(err) {
+		lgr.Info("pod doesn't exist anymore")
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("getting pod: %w", err)
+	}
+
+	if !podIsReady(&obj) {
+		lgr.Info("pod isn't ready anymore")
+		return false, nil
+	}
+
+	return true, nil
 }

--- a/pkg/controller/ingress/concurrency_watchdog.go
+++ b/pkg/controller/ingress/concurrency_watchdog.go
@@ -356,6 +356,7 @@ func podIsActive(ctx context.Context, lgr logr.Logger, cl client.Client, pod cli
 		return false, nil
 	}
 	if err != nil {
+		lgr.Error(err, "failed to get pod")
 		return false, fmt.Errorf("getting pod: %w", err)
 	}
 


### PR DESCRIPTION
# Description

Adds an is active check to the concurrency watchdog before we error out (because we can't get a pod metric). This solves a race condition where
1. we check if pod is ready (and see it is)
2. we try to get pod metrics but can't
3. pod was deleted or became unready between 1 and 2

This fix mostly is just for monitoring/metric purposes, so we stop reporting false alarms