### PR TITLE
HTTP Disabled Flag for Nginx Ingress Config

### DIFF
--- a/pkg/manifests/fixtures/nginx/default_version/full-with-http-disabled.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/full-with-http-disabled.yaml
@@ -1,0 +1,488 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  creationTimestamp: null
+  labels:
+    openservicemesh.io/monitored-by: osm
+  name: test-namespace
+spec: {}
+status: {}
+---
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: webapprouting.kubernetes.azure.com
+spec:
+  controller: webapprouting.kubernetes.azure.com/nginx
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: ingress-controller
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx
+  namespace: test-namespace
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: ingress-controller
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - endpoints
+  - nodes
+  - pods
+  - secrets
+  - namespaces
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses/status
+  verbs:
+  - update
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingressclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - list
+  - watch
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: ingress-controller
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx
+  namespace: test-namespace
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - pods
+  - secrets
+  - endpoints
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses/status
+  verbs:
+  - update
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingressclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resourceNames:
+  - nginx
+  resources:
+  - leases
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - list
+  - watch
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: ingress-controller
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nginx
+subjects:
+- kind: ServiceAccount
+  name: nginx
+  namespace: test-namespace
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: ingress-controller
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx
+  namespace: test-namespace
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: nginx
+subjects:
+- kind: ServiceAccount
+  name: nginx
+  namespace: test-namespace
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.kubernetes.io/azure-load-balancer-internal: "true"
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: ingress-controller
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx
+  namespace: test-namespace
+spec:
+  externalTrafficPolicy: Local
+  ports:
+  - name: https
+    port: 443
+    targetPort: https
+  selector:
+    app: nginx
+  type: LoadBalancer
+status:
+  loadBalancer: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "10254"
+    prometheus.io/scrape: "true"
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: ingress-controller
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx-metrics
+  namespace: test-namespace
+spec:
+  ports:
+  - name: prometheus
+    port: 10254
+    targetPort: prometheus
+  selector:
+    app: nginx
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: ingress-controller
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx
+  namespace: test-namespace
+spec:
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: nginx
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        openservicemesh.io/sidecar-injection: disabled
+        prometheus.io/port: "10254"
+        prometheus.io/scrape: "true"
+      creationTimestamp: null
+      labels:
+        app: nginx
+        app.kubernetes.io/component: ingress-controller
+        app.kubernetes.io/managed-by: aks-app-routing-operator
+        kubernetes.azure.com/managedby: aks
+    spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: kubernetes.azure.com/mode
+                operator: In
+                values:
+                - system
+            weight: 100
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.azure.com/cluster
+                operator: Exists
+              - key: type
+                operator: NotIn
+                values:
+                - virtual-kubelet
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+      containers:
+      - args:
+        - /nginx-ingress-controller
+        - --ingress-class=webapprouting.kubernetes.azure.com
+        - --controller-class=webapprouting.kubernetes.azure.com/nginx
+        - --election-id=nginx
+        - --publish-service=$(POD_NAMESPACE)/nginx
+        - --configmap=$(POD_NAMESPACE)/nginx
+        - --enable-annotation-validation=true
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: test-registry/oss/kubernetes/ingress/nginx-ingress-controller:v1.11.2
+        livenessProbe:
+          failureThreshold: 6
+          httpGet:
+            path: /healthz
+            port: 10254
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: controller
+        ports:
+        - containerPort: 443
+          name: https
+        - containerPort: 10254
+          name: prometheus
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 10254
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 500m
+            memory: 127Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add:
+            - NET_BIND_SERVICE
+            drop:
+            - ALL
+          runAsNonRoot: true
+          runAsUser: 101
+          seccompProfile:
+            type: RuntimeDefault
+      priorityClassName: system-cluster-critical
+      serviceAccountName: nginx
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app: nginx
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+status: {}
+---
+apiVersion: v1
+data:
+  allow-snippet-annotations: "true"
+  annotation-value-word-blocklist: load_module,lua_package,_by_lua,location,root,proxy_pass,serviceaccount,{,},'
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: ingress-controller
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx
+  namespace: test-namespace
+---
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: ingress-controller
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx
+  namespace: test-namespace
+spec:
+  maxReplicas: 100
+  minReplicas: 2
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: nginx
+  targetCPUUtilizationPercentage: 80
+status:
+  currentReplicas: 0
+  desiredReplicas: 0
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: ingress-controller
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx
+  namespace: test-namespace
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: nginx
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0
+---

--- a/pkg/manifests/fixtures/nginx/default_version/internal-with-http-disabled.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/internal-with-http-disabled.yaml
@@ -1,0 +1,486 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  creationTimestamp: null
+  labels:
+    openservicemesh.io/monitored-by: osm
+  name: test-namespace
+spec: {}
+status: {}
+---
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx-private
+spec:
+  controller: test-controller-class
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: ingress-controller
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx
+  namespace: test-namespace
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: ingress-controller
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - endpoints
+  - nodes
+  - pods
+  - secrets
+  - namespaces
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses/status
+  verbs:
+  - update
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingressclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - list
+  - watch
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: ingress-controller
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx
+  namespace: test-namespace
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - pods
+  - secrets
+  - endpoints
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses/status
+  verbs:
+  - update
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingressclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resourceNames:
+  - nginx
+  resources:
+  - leases
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - list
+  - watch
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: ingress-controller
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nginx
+subjects:
+- kind: ServiceAccount
+  name: nginx
+  namespace: test-namespace
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: ingress-controller
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx
+  namespace: test-namespace
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: nginx
+subjects:
+- kind: ServiceAccount
+  name: nginx
+  namespace: test-namespace
+---
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: ingress-controller
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx
+  namespace: test-namespace
+spec:
+  externalTrafficPolicy: Local
+  ports:
+  - name: https
+    port: 443
+    targetPort: https
+  selector:
+    app: nginx
+  type: LoadBalancer
+status:
+  loadBalancer: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "10254"
+    prometheus.io/scrape: "true"
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: ingress-controller
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx-metrics
+  namespace: test-namespace
+spec:
+  ports:
+  - name: prometheus
+    port: 10254
+    targetPort: prometheus
+  selector:
+    app: nginx
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: ingress-controller
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx
+  namespace: test-namespace
+spec:
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: nginx
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        openservicemesh.io/sidecar-injection: disabled
+        prometheus.io/port: "10254"
+        prometheus.io/scrape: "true"
+      creationTimestamp: null
+      labels:
+        app: nginx
+        app.kubernetes.io/component: ingress-controller
+        app.kubernetes.io/managed-by: aks-app-routing-operator
+        kubernetes.azure.com/managedby: aks
+    spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: kubernetes.azure.com/mode
+                operator: In
+                values:
+                - system
+            weight: 100
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.azure.com/cluster
+                operator: Exists
+              - key: type
+                operator: NotIn
+                values:
+                - virtual-kubelet
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+      containers:
+      - args:
+        - /nginx-ingress-controller
+        - --ingress-class=nginx-private
+        - --controller-class=test-controller-class
+        - --election-id=nginx
+        - --publish-service=$(POD_NAMESPACE)/nginx
+        - --configmap=$(POD_NAMESPACE)/nginx
+        - --enable-annotation-validation=true
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: test-registry/oss/kubernetes/ingress/nginx-ingress-controller:v1.11.2
+        livenessProbe:
+          failureThreshold: 6
+          httpGet:
+            path: /healthz
+            port: 10254
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: controller
+        ports:
+        - containerPort: 443
+          name: https
+        - containerPort: 10254
+          name: prometheus
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 10254
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 500m
+            memory: 127Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add:
+            - NET_BIND_SERVICE
+            drop:
+            - ALL
+          runAsNonRoot: true
+          runAsUser: 101
+          seccompProfile:
+            type: RuntimeDefault
+      priorityClassName: system-cluster-critical
+      serviceAccountName: nginx
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app: nginx
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+status: {}
+---
+apiVersion: v1
+data:
+  allow-snippet-annotations: "true"
+  annotation-value-word-blocklist: load_module,lua_package,_by_lua,location,root,proxy_pass,serviceaccount,{,},'
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: ingress-controller
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx
+  namespace: test-namespace
+---
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: ingress-controller
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx
+  namespace: test-namespace
+spec:
+  maxReplicas: 100
+  minReplicas: 2
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: nginx
+  targetCPUUtilizationPercentage: 80
+status:
+  currentReplicas: 0
+  desiredReplicas: 0
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: ingress-controller
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx
+  namespace: test-namespace
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: nginx
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0
+---

--- a/pkg/manifests/fixtures/nginx/v1.10.0/full-with-http-disabled.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.10.0/full-with-http-disabled.yaml
@@ -1,0 +1,488 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  creationTimestamp: null
+  labels:
+    openservicemesh.io/monitored-by: osm
+  name: test-namespace
+spec: {}
+status: {}
+---
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: webapprouting.kubernetes.azure.com
+spec:
+  controller: webapprouting.kubernetes.azure.com/nginx
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: ingress-controller
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx
+  namespace: test-namespace
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: ingress-controller
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - endpoints
+  - nodes
+  - pods
+  - secrets
+  - namespaces
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses/status
+  verbs:
+  - update
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingressclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - list
+  - watch
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: ingress-controller
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx
+  namespace: test-namespace
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - pods
+  - secrets
+  - endpoints
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses/status
+  verbs:
+  - update
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingressclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resourceNames:
+  - nginx
+  resources:
+  - leases
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - list
+  - watch
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: ingress-controller
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nginx
+subjects:
+- kind: ServiceAccount
+  name: nginx
+  namespace: test-namespace
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: ingress-controller
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx
+  namespace: test-namespace
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: nginx
+subjects:
+- kind: ServiceAccount
+  name: nginx
+  namespace: test-namespace
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.kubernetes.io/azure-load-balancer-internal: "true"
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: ingress-controller
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx
+  namespace: test-namespace
+spec:
+  externalTrafficPolicy: Local
+  ports:
+  - name: https
+    port: 443
+    targetPort: https
+  selector:
+    app: nginx
+  type: LoadBalancer
+status:
+  loadBalancer: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "10254"
+    prometheus.io/scrape: "true"
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: ingress-controller
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx-metrics
+  namespace: test-namespace
+spec:
+  ports:
+  - name: prometheus
+    port: 10254
+    targetPort: prometheus
+  selector:
+    app: nginx
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: ingress-controller
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx
+  namespace: test-namespace
+spec:
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: nginx
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        openservicemesh.io/sidecar-injection: disabled
+        prometheus.io/port: "10254"
+        prometheus.io/scrape: "true"
+      creationTimestamp: null
+      labels:
+        app: nginx
+        app.kubernetes.io/component: ingress-controller
+        app.kubernetes.io/managed-by: aks-app-routing-operator
+        kubernetes.azure.com/managedby: aks
+    spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: kubernetes.azure.com/mode
+                operator: In
+                values:
+                - system
+            weight: 100
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.azure.com/cluster
+                operator: Exists
+              - key: type
+                operator: NotIn
+                values:
+                - virtual-kubelet
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+      containers:
+      - args:
+        - /nginx-ingress-controller
+        - --ingress-class=webapprouting.kubernetes.azure.com
+        - --controller-class=webapprouting.kubernetes.azure.com/nginx
+        - --election-id=nginx
+        - --publish-service=$(POD_NAMESPACE)/nginx
+        - --configmap=$(POD_NAMESPACE)/nginx
+        - --enable-annotation-validation=true
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: test-registry/oss/kubernetes/ingress/nginx-ingress-controller:v1.11.2
+        livenessProbe:
+          failureThreshold: 6
+          httpGet:
+            path: /healthz
+            port: 10254
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: controller
+        ports:
+        - containerPort: 443
+          name: https
+        - containerPort: 10254
+          name: prometheus
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 10254
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 500m
+            memory: 127Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add:
+            - NET_BIND_SERVICE
+            drop:
+            - ALL
+          runAsNonRoot: true
+          runAsUser: 101
+          seccompProfile:
+            type: RuntimeDefault
+      priorityClassName: system-cluster-critical
+      serviceAccountName: nginx
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app: nginx
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+status: {}
+---
+apiVersion: v1
+data:
+  allow-snippet-annotations: "true"
+  annotation-value-word-blocklist: load_module,lua_package,_by_lua,location,root,proxy_pass,serviceaccount,{,},'
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: ingress-controller
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx
+  namespace: test-namespace
+---
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: ingress-controller
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx
+  namespace: test-namespace
+spec:
+  maxReplicas: 100
+  minReplicas: 2
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: nginx
+  targetCPUUtilizationPercentage: 80
+status:
+  currentReplicas: 0
+  desiredReplicas: 0
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: ingress-controller
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx
+  namespace: test-namespace
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: nginx
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0
+---

--- a/pkg/manifests/fixtures/nginx/v1.10.0/internal-with-http-disabled.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.10.0/internal-with-http-disabled.yaml
@@ -1,0 +1,486 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  creationTimestamp: null
+  labels:
+    openservicemesh.io/monitored-by: osm
+  name: test-namespace
+spec: {}
+status: {}
+---
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx-private
+spec:
+  controller: test-controller-class
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: ingress-controller
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx
+  namespace: test-namespace
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: ingress-controller
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - endpoints
+  - nodes
+  - pods
+  - secrets
+  - namespaces
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses/status
+  verbs:
+  - update
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingressclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - list
+  - watch
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: ingress-controller
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx
+  namespace: test-namespace
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - pods
+  - secrets
+  - endpoints
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses/status
+  verbs:
+  - update
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingressclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resourceNames:
+  - nginx
+  resources:
+  - leases
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - list
+  - watch
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: ingress-controller
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nginx
+subjects:
+- kind: ServiceAccount
+  name: nginx
+  namespace: test-namespace
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: ingress-controller
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx
+  namespace: test-namespace
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: nginx
+subjects:
+- kind: ServiceAccount
+  name: nginx
+  namespace: test-namespace
+---
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: ingress-controller
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx
+  namespace: test-namespace
+spec:
+  externalTrafficPolicy: Local
+  ports:
+  - name: https
+    port: 443
+    targetPort: https
+  selector:
+    app: nginx
+  type: LoadBalancer
+status:
+  loadBalancer: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "10254"
+    prometheus.io/scrape: "true"
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: ingress-controller
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx-metrics
+  namespace: test-namespace
+spec:
+  ports:
+  - name: prometheus
+    port: 10254
+    targetPort: prometheus
+  selector:
+    app: nginx
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: ingress-controller
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx
+  namespace: test-namespace
+spec:
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: nginx
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        openservicemesh.io/sidecar-injection: disabled
+        prometheus.io/port: "10254"
+        prometheus.io/scrape: "true"
+      creationTimestamp: null
+      labels:
+        app: nginx
+        app.kubernetes.io/component: ingress-controller
+        app.kubernetes.io/managed-by: aks-app-routing-operator
+        kubernetes.azure.com/managedby: aks
+    spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: kubernetes.azure.com/mode
+                operator: In
+                values:
+                - system
+            weight: 100
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.azure.com/cluster
+                operator: Exists
+              - key: type
+                operator: NotIn
+                values:
+                - virtual-kubelet
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+      containers:
+      - args:
+        - /nginx-ingress-controller
+        - --ingress-class=nginx-private
+        - --controller-class=test-controller-class
+        - --election-id=nginx
+        - --publish-service=$(POD_NAMESPACE)/nginx
+        - --configmap=$(POD_NAMESPACE)/nginx
+        - --enable-annotation-validation=true
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: test-registry/oss/kubernetes/ingress/nginx-ingress-controller:v1.11.2
+        livenessProbe:
+          failureThreshold: 6
+          httpGet:
+            path: /healthz
+            port: 10254
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: controller
+        ports:
+        - containerPort: 443
+          name: https
+        - containerPort: 10254
+          name: prometheus
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 10254
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 500m
+            memory: 127Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add:
+            - NET_BIND_SERVICE
+            drop:
+            - ALL
+          runAsNonRoot: true
+          runAsUser: 101
+          seccompProfile:
+            type: RuntimeDefault
+      priorityClassName: system-cluster-critical
+      serviceAccountName: nginx
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app: nginx
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+status: {}
+---
+apiVersion: v1
+data:
+  allow-snippet-annotations: "true"
+  annotation-value-word-blocklist: load_module,lua_package,_by_lua,location,root,proxy_pass,serviceaccount,{,},'
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: ingress-controller
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx
+  namespace: test-namespace
+---
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: ingress-controller
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx
+  namespace: test-namespace
+spec:
+  maxReplicas: 100
+  minReplicas: 2
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: nginx
+  targetCPUUtilizationPercentage: 80
+status:
+  currentReplicas: 0
+  desiredReplicas: 0
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: ingress-controller
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx
+  namespace: test-namespace
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: nginx
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0
+---

--- a/pkg/manifests/fixtures/nginx/v1.11.2/full-with-http-disabled.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.11.2/full-with-http-disabled.yaml
@@ -1,0 +1,488 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  creationTimestamp: null
+  labels:
+    openservicemesh.io/monitored-by: osm
+  name: test-namespace
+spec: {}
+status: {}
+---
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: webapprouting.kubernetes.azure.com
+spec:
+  controller: webapprouting.kubernetes.azure.com/nginx
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: ingress-controller
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx
+  namespace: test-namespace
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: ingress-controller
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - endpoints
+  - nodes
+  - pods
+  - secrets
+  - namespaces
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses/status
+  verbs:
+  - update
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingressclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - list
+  - watch
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: ingress-controller
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx
+  namespace: test-namespace
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - pods
+  - secrets
+  - endpoints
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses/status
+  verbs:
+  - update
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingressclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resourceNames:
+  - nginx
+  resources:
+  - leases
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - list
+  - watch
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: ingress-controller
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nginx
+subjects:
+- kind: ServiceAccount
+  name: nginx
+  namespace: test-namespace
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: ingress-controller
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx
+  namespace: test-namespace
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: nginx
+subjects:
+- kind: ServiceAccount
+  name: nginx
+  namespace: test-namespace
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.kubernetes.io/azure-load-balancer-internal: "true"
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: ingress-controller
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx
+  namespace: test-namespace
+spec:
+  externalTrafficPolicy: Local
+  ports:
+  - name: https
+    port: 443
+    targetPort: https
+  selector:
+    app: nginx
+  type: LoadBalancer
+status:
+  loadBalancer: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "10254"
+    prometheus.io/scrape: "true"
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: ingress-controller
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx-metrics
+  namespace: test-namespace
+spec:
+  ports:
+  - name: prometheus
+    port: 10254
+    targetPort: prometheus
+  selector:
+    app: nginx
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: ingress-controller
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx
+  namespace: test-namespace
+spec:
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: nginx
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        openservicemesh.io/sidecar-injection: disabled
+        prometheus.io/port: "10254"
+        prometheus.io/scrape: "true"
+      creationTimestamp: null
+      labels:
+        app: nginx
+        app.kubernetes.io/component: ingress-controller
+        app.kubernetes.io/managed-by: aks-app-routing-operator
+        kubernetes.azure.com/managedby: aks
+    spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: kubernetes.azure.com/mode
+                operator: In
+                values:
+                - system
+            weight: 100
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.azure.com/cluster
+                operator: Exists
+              - key: type
+                operator: NotIn
+                values:
+                - virtual-kubelet
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+      containers:
+      - args:
+        - /nginx-ingress-controller
+        - --ingress-class=webapprouting.kubernetes.azure.com
+        - --controller-class=webapprouting.kubernetes.azure.com/nginx
+        - --election-id=nginx
+        - --publish-service=$(POD_NAMESPACE)/nginx
+        - --configmap=$(POD_NAMESPACE)/nginx
+        - --enable-annotation-validation=true
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: test-registry/oss/kubernetes/ingress/nginx-ingress-controller:v1.11.2
+        livenessProbe:
+          failureThreshold: 6
+          httpGet:
+            path: /healthz
+            port: 10254
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: controller
+        ports:
+        - containerPort: 443
+          name: https
+        - containerPort: 10254
+          name: prometheus
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 10254
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 500m
+            memory: 127Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add:
+            - NET_BIND_SERVICE
+            drop:
+            - ALL
+          runAsNonRoot: true
+          runAsUser: 101
+          seccompProfile:
+            type: RuntimeDefault
+      priorityClassName: system-cluster-critical
+      serviceAccountName: nginx
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app: nginx
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+status: {}
+---
+apiVersion: v1
+data:
+  allow-snippet-annotations: "true"
+  annotation-value-word-blocklist: load_module,lua_package,_by_lua,location,root,proxy_pass,serviceaccount,{,},'
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: ingress-controller
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx
+  namespace: test-namespace
+---
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: ingress-controller
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx
+  namespace: test-namespace
+spec:
+  maxReplicas: 100
+  minReplicas: 2
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: nginx
+  targetCPUUtilizationPercentage: 80
+status:
+  currentReplicas: 0
+  desiredReplicas: 0
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: ingress-controller
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx
+  namespace: test-namespace
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: nginx
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0
+---

--- a/pkg/manifests/fixtures/nginx/v1.11.2/internal-with-http-disabled.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.11.2/internal-with-http-disabled.yaml
@@ -1,0 +1,486 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  creationTimestamp: null
+  labels:
+    openservicemesh.io/monitored-by: osm
+  name: test-namespace
+spec: {}
+status: {}
+---
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx-private
+spec:
+  controller: test-controller-class
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: ingress-controller
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx
+  namespace: test-namespace
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: ingress-controller
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - endpoints
+  - nodes
+  - pods
+  - secrets
+  - namespaces
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses/status
+  verbs:
+  - update
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingressclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - list
+  - watch
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: ingress-controller
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx
+  namespace: test-namespace
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - pods
+  - secrets
+  - endpoints
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses/status
+  verbs:
+  - update
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingressclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resourceNames:
+  - nginx
+  resources:
+  - leases
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - list
+  - watch
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: ingress-controller
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nginx
+subjects:
+- kind: ServiceAccount
+  name: nginx
+  namespace: test-namespace
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: ingress-controller
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx
+  namespace: test-namespace
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: nginx
+subjects:
+- kind: ServiceAccount
+  name: nginx
+  namespace: test-namespace
+---
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: ingress-controller
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx
+  namespace: test-namespace
+spec:
+  externalTrafficPolicy: Local
+  ports:
+  - name: https
+    port: 443
+    targetPort: https
+  selector:
+    app: nginx
+  type: LoadBalancer
+status:
+  loadBalancer: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "10254"
+    prometheus.io/scrape: "true"
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: ingress-controller
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx-metrics
+  namespace: test-namespace
+spec:
+  ports:
+  - name: prometheus
+    port: 10254
+    targetPort: prometheus
+  selector:
+    app: nginx
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: ingress-controller
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx
+  namespace: test-namespace
+spec:
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: nginx
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        openservicemesh.io/sidecar-injection: disabled
+        prometheus.io/port: "10254"
+        prometheus.io/scrape: "true"
+      creationTimestamp: null
+      labels:
+        app: nginx
+        app.kubernetes.io/component: ingress-controller
+        app.kubernetes.io/managed-by: aks-app-routing-operator
+        kubernetes.azure.com/managedby: aks
+    spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: kubernetes.azure.com/mode
+                operator: In
+                values:
+                - system
+            weight: 100
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.azure.com/cluster
+                operator: Exists
+              - key: type
+                operator: NotIn
+                values:
+                - virtual-kubelet
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+      containers:
+      - args:
+        - /nginx-ingress-controller
+        - --ingress-class=nginx-private
+        - --controller-class=test-controller-class
+        - --election-id=nginx
+        - --publish-service=$(POD_NAMESPACE)/nginx
+        - --configmap=$(POD_NAMESPACE)/nginx
+        - --enable-annotation-validation=true
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: test-registry/oss/kubernetes/ingress/nginx-ingress-controller:v1.11.2
+        livenessProbe:
+          failureThreshold: 6
+          httpGet:
+            path: /healthz
+            port: 10254
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: controller
+        ports:
+        - containerPort: 443
+          name: https
+        - containerPort: 10254
+          name: prometheus
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 10254
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 500m
+            memory: 127Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add:
+            - NET_BIND_SERVICE
+            drop:
+            - ALL
+          runAsNonRoot: true
+          runAsUser: 101
+          seccompProfile:
+            type: RuntimeDefault
+      priorityClassName: system-cluster-critical
+      serviceAccountName: nginx
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app: nginx
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+status: {}
+---
+apiVersion: v1
+data:
+  allow-snippet-annotations: "true"
+  annotation-value-word-blocklist: load_module,lua_package,_by_lua,location,root,proxy_pass,serviceaccount,{,},'
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: ingress-controller
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx
+  namespace: test-namespace
+---
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: ingress-controller
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx
+  namespace: test-namespace
+spec:
+  maxReplicas: 100
+  minReplicas: 2
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: nginx
+  targetCPUUtilizationPercentage: 80
+status:
+  currentReplicas: 0
+  desiredReplicas: 0
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: ingress-controller
+    app.kubernetes.io/managed-by: aks-app-routing-operator
+    app.kubernetes.io/name: nginx
+    kubernetes.azure.com/managedby: aks
+  name: nginx
+  namespace: test-namespace
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: nginx
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0
+---

--- a/pkg/manifests/nginx.go
+++ b/pkg/manifests/nginx.go
@@ -310,7 +310,7 @@ func newNginxIngressControllerService(conf *config.Config, ingressConfig *NginxI
 		}
 	}
 
-	return &corev1.Service{
+	ret := &corev1.Service{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Service",
 			APIVersion: "v1",
@@ -327,11 +327,6 @@ func newNginxIngressControllerService(conf *config.Config, ingressConfig *NginxI
 			Selector:              ingressConfig.PodLabels(),
 			Ports: []corev1.ServicePort{
 				{
-					Name:       "http",
-					Port:       80,
-					TargetPort: intstr.FromString("http"),
-				},
-				{
 					Name:       "https",
 					Port:       443,
 					TargetPort: intstr.FromString("https"),
@@ -339,6 +334,18 @@ func newNginxIngressControllerService(conf *config.Config, ingressConfig *NginxI
 			},
 		},
 	}
+
+	if ingressConfig.HTTPEnabled {
+		ret.Spec.Ports = append([]corev1.ServicePort{
+			{
+				Name:       "http",
+				Port:       80,
+				TargetPort: intstr.FromString("http"),
+			},
+		}, ret.Spec.Ports...)
+	}
+
+	return ret
 }
 
 func newNginxIngressControllerPromService(conf *config.Config, ingressConfig *NginxIngressConfig) *corev1.Service {

--- a/pkg/manifests/nginx_test.go
+++ b/pkg/manifests/nginx_test.go
@@ -41,7 +41,6 @@ var (
 				"service.beta.kubernetes.io/azure-load-balancer-internal": "true",
 			},
 		},
-		HTTPEnabled:                    true,
 		MinReplicas:                    2,
 		MaxReplicas:                    100,
 		TargetCPUUtilizationPercentage: 80,
@@ -128,7 +127,6 @@ var (
 				ControllerClass:                "test-controller-class",
 				ResourceName:                   "nginx",
 				IcName:                         "nginx-private",
-				HTTPEnabled:                    true,
 				MinReplicas:                    2,
 				MaxReplicas:                    100,
 				TargetCPUUtilizationPercentage: 80,
@@ -154,7 +152,6 @@ var (
 				ControllerClass:                "test-controller-class",
 				ResourceName:                   "nginx",
 				IcName:                         "nginx-private",
-				HTTPEnabled:                    true,
 				DefaultSSLCertificate:          "fakenamespace/fakename",
 				MinReplicas:                    2,
 				MaxReplicas:                    100,
@@ -181,7 +178,6 @@ var (
 				ControllerClass:                "test-controller-class",
 				ResourceName:                   "nginx",
 				IcName:                         "nginx-private",
-				HTTPEnabled:                    true,
 				DefaultSSLCertificate:          "fakenamespace/fakename",
 				ForceSSLRedirect:               true,
 				MinReplicas:                    2,
@@ -209,7 +205,6 @@ var (
 				ControllerClass:                "test-controller-class",
 				ResourceName:                   "nginx",
 				IcName:                         "nginx-private",
-				HTTPEnabled:                    true,
 				DefaultBackendService:          "fakenamespace/fakename",
 				ForceSSLRedirect:               true,
 				MinReplicas:                    2,
@@ -238,7 +233,6 @@ var (
 				ResourceName:                   "nginx",
 				IcName:                         "nginx-private",
 				CustomHTTPErrors:               "404,503",
-				HTTPEnabled:                    true,
 				MinReplicas:                    2,
 				MaxReplicas:                    100,
 				TargetCPUUtilizationPercentage: 80,
@@ -265,7 +259,6 @@ var (
 				ResourceName:                   "nginx",
 				IcName:                         "nginx-private",
 				CustomHTTPErrors:               "404,503",
-				HTTPEnabled:                    true,
 				DefaultSSLCertificate:          "fakesslnamespace/fakesslname",
 				DefaultBackendService:          "fakebackendnamespace/fakebackendname",
 				ForceSSLRedirect:               true,
@@ -294,7 +287,6 @@ var (
 				ControllerClass:                "test-controller-class",
 				ResourceName:                   "nginx",
 				IcName:                         "nginx-private",
-				HTTPEnabled:                    true,
 				DefaultSSLCertificate:          "fakesslnamespace/fakesslname",
 				DefaultBackendService:          "fakebackendnamespace/fakebackendname",
 				ForceSSLRedirect:               true,
@@ -323,7 +315,6 @@ var (
 				ControllerClass:                "test-controller-class",
 				ResourceName:                   "nginx",
 				IcName:                         "nginx-private",
-				HTTPEnabled:                    true,
 				DefaultSSLCertificate:          "",
 				ForceSSLRedirect:               true,
 				MinReplicas:                    2,
@@ -380,6 +371,32 @@ var (
 			}(),
 		},
 		{
+			Name: "internal-with-http-disabled",
+			Conf: &config.Config{
+				NS:          "test-namespace",
+				Registry:    "test-registry",
+				MSIClientID: "test-msi-client-id",
+				TenantID:    "test-tenant-id",
+				Cloud:       "test-cloud",
+				Location:    "test-location",
+			},
+			Deploy: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-operator-deploy",
+					UID:  "test-operator-deploy-uid",
+				},
+			},
+			IngConfig: &NginxIngressConfig{
+				ControllerClass:                "test-controller-class",
+				ResourceName:                   "nginx",
+				IcName:                         "nginx-private",
+				HTTPDisabled:                   true,
+				MinReplicas:                    2,
+				MaxReplicas:                    100,
+				TargetCPUUtilizationPercentage: 80,
+			},
+		},
+		{
 			Name: "full-with-http-disabled",
 			Conf: &config.Config{
 				NS:          "test-namespace",
@@ -397,7 +414,7 @@ var (
 			},
 			IngConfig: func() *NginxIngressConfig {
 				copy := *ingConfig
-				copy.HTTPEnabled = false
+				copy.HTTPDisabled = true
 				return &copy
 			}(),
 		},

--- a/pkg/manifests/nginx_test.go
+++ b/pkg/manifests/nginx_test.go
@@ -440,13 +440,6 @@ func TestIngressControllerResources(t *testing.T) {
 			tc.IngConfig.Version = version
 			objs := GetNginxResources(tc.Conf, tc.IngConfig)
 
-			httpEnabled := tc.IngConfig.HTTPEnabled
-			for _, servicePort := range objs.Service.Spec.Ports {
-				if servicePort.Name == "http" && !httpEnabled {
-					t.Errorf("http port should not be enabled")
-				}
-			}
-
 			versionName := "default_version"
 			if version != nil {
 				versionName = version.name

--- a/pkg/manifests/types.go
+++ b/pkg/manifests/types.go
@@ -59,7 +59,7 @@ type NginxIngressConfig struct {
 	IcName                string         // IngressClass name
 	ServiceConfig         *ServiceConfig // service config that specifies details about the LB, defaults if nil
 	ForceSSLRedirect      bool           // flag to sets all redirects to HTTPS if there is a default TLS certificate (requires DefaultSSLCertificate)
-	HTTPEnabled           bool           // flag to enable HTTP server
+	HTTPDisabled          bool           // flag to disable HTTP server
 	DefaultSSLCertificate string         // namespace/name used to create SSL certificate for the default HTTPS server (catch-all)
 	DefaultBackendService string         // namespace/name used to determine default backend service for / and /healthz endpoints
 	CustomHTTPErrors      string         // error codes passed to the configmap to configure nginx to send traffic with the specified headers to its defaultbackend service in case of error

--- a/pkg/manifests/types.go
+++ b/pkg/manifests/types.go
@@ -59,6 +59,7 @@ type NginxIngressConfig struct {
 	IcName                string         // IngressClass name
 	ServiceConfig         *ServiceConfig // service config that specifies details about the LB, defaults if nil
 	ForceSSLRedirect      bool           // flag to sets all redirects to HTTPS if there is a default TLS certificate (requires DefaultSSLCertificate)
+	HTTPEnabled           bool           // flag to enable HTTP server
 	DefaultSSLCertificate string         // namespace/name used to create SSL certificate for the default HTTPS server (catch-all)
 	DefaultBackendService string         // namespace/name used to determine default backend service for / and /healthz endpoints
 	CustomHTTPErrors      string         // error codes passed to the configmap to configure nginx to send traffic with the specified headers to its defaultbackend service in case of error


### PR DESCRIPTION
# Description

This PR adds a new flag to the NginxIngressConfig struct, HTTPDisabled, which allows users to set up their Nginx Ingress without HTTP. Also, includes testing for this feature.

Fixes # (issue)
Feature # (details)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Is it a breaking change which will impact consuming tool(s)?

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
