### PR TITLE
respect rollouts in ingress controller topology spread

### DIFF
--- a/pkg/manifests/fixtures/nginx/default_version/full-with-http-disabled.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/full-with-http-disabled.yaml
@@ -421,6 +421,8 @@ spec:
       - labelSelector:
           matchLabels:
             app: nginx
+        matchLabelKeys:
+        - pod-template-hash
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
         whenUnsatisfiable: ScheduleAnyway

--- a/pkg/manifests/fixtures/nginx/default_version/full-with-replicas.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/full-with-replicas.yaml
@@ -426,6 +426,8 @@ spec:
       - labelSelector:
           matchLabels:
             app: nginx
+        matchLabelKeys:
+        - pod-template-hash
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
         whenUnsatisfiable: ScheduleAnyway

--- a/pkg/manifests/fixtures/nginx/default_version/full-with-target-cpu.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/full-with-target-cpu.yaml
@@ -426,6 +426,8 @@ spec:
       - labelSelector:
           matchLabels:
             app: nginx
+        matchLabelKeys:
+        - pod-template-hash
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
         whenUnsatisfiable: ScheduleAnyway

--- a/pkg/manifests/fixtures/nginx/default_version/full.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/full.yaml
@@ -426,6 +426,8 @@ spec:
       - labelSelector:
           matchLabels:
             app: nginx
+        matchLabelKeys:
+        - pod-template-hash
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
         whenUnsatisfiable: ScheduleAnyway

--- a/pkg/manifests/fixtures/nginx/default_version/internal-with-custom-http-errors-cert-and-service.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/internal-with-custom-http-errors-cert-and-service.yaml
@@ -426,6 +426,8 @@ spec:
       - labelSelector:
           matchLabels:
             app: nginx
+        matchLabelKeys:
+        - pod-template-hash
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
         whenUnsatisfiable: ScheduleAnyway

--- a/pkg/manifests/fixtures/nginx/default_version/internal-with-custom-http-errors.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/internal-with-custom-http-errors.yaml
@@ -424,6 +424,8 @@ spec:
       - labelSelector:
           matchLabels:
             app: nginx
+        matchLabelKeys:
+        - pod-template-hash
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
         whenUnsatisfiable: ScheduleAnyway

--- a/pkg/manifests/fixtures/nginx/default_version/internal-with-default-backend-service-and-ssl-cert.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/internal-with-default-backend-service-and-ssl-cert.yaml
@@ -426,6 +426,8 @@ spec:
       - labelSelector:
           matchLabels:
             app: nginx
+        matchLabelKeys:
+        - pod-template-hash
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
         whenUnsatisfiable: ScheduleAnyway

--- a/pkg/manifests/fixtures/nginx/default_version/internal-with-default-backend-service.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/internal-with-default-backend-service.yaml
@@ -425,6 +425,8 @@ spec:
       - labelSelector:
           matchLabels:
             app: nginx
+        matchLabelKeys:
+        - pod-template-hash
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
         whenUnsatisfiable: ScheduleAnyway

--- a/pkg/manifests/fixtures/nginx/default_version/internal-with-http-disabled.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/internal-with-http-disabled.yaml
@@ -419,6 +419,8 @@ spec:
       - labelSelector:
           matchLabels:
             app: nginx
+        matchLabelKeys:
+        - pod-template-hash
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
         whenUnsatisfiable: ScheduleAnyway

--- a/pkg/manifests/fixtures/nginx/default_version/internal-with-nil-ssl-cert-and-force-ssl.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/internal-with-nil-ssl-cert-and-force-ssl.yaml
@@ -424,6 +424,8 @@ spec:
       - labelSelector:
           matchLabels:
             app: nginx
+        matchLabelKeys:
+        - pod-template-hash
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
         whenUnsatisfiable: ScheduleAnyway

--- a/pkg/manifests/fixtures/nginx/default_version/internal-with-ssl-cert-and-force-ssl.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/internal-with-ssl-cert-and-force-ssl.yaml
@@ -425,6 +425,8 @@ spec:
       - labelSelector:
           matchLabels:
             app: nginx
+        matchLabelKeys:
+        - pod-template-hash
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
         whenUnsatisfiable: ScheduleAnyway

--- a/pkg/manifests/fixtures/nginx/default_version/internal-with-ssl-cert.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/internal-with-ssl-cert.yaml
@@ -425,6 +425,8 @@ spec:
       - labelSelector:
           matchLabels:
             app: nginx
+        matchLabelKeys:
+        - pod-template-hash
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
         whenUnsatisfiable: ScheduleAnyway

--- a/pkg/manifests/fixtures/nginx/default_version/internal.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/internal.yaml
@@ -424,6 +424,8 @@ spec:
       - labelSelector:
           matchLabels:
             app: nginx
+        matchLabelKeys:
+        - pod-template-hash
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
         whenUnsatisfiable: ScheduleAnyway

--- a/pkg/manifests/fixtures/nginx/default_version/kube-system.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/kube-system.yaml
@@ -416,6 +416,8 @@ spec:
       - labelSelector:
           matchLabels:
             app: nginx
+        matchLabelKeys:
+        - pod-template-hash
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
         whenUnsatisfiable: ScheduleAnyway

--- a/pkg/manifests/fixtures/nginx/default_version/no-ownership.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/no-ownership.yaml
@@ -426,6 +426,8 @@ spec:
       - labelSelector:
           matchLabels:
             app: nginx
+        matchLabelKeys:
+        - pod-template-hash
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
         whenUnsatisfiable: ScheduleAnyway

--- a/pkg/manifests/fixtures/nginx/default_version/optional-features-disabled.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/optional-features-disabled.yaml
@@ -423,6 +423,8 @@ spec:
       - labelSelector:
           matchLabels:
             app: nginx
+        matchLabelKeys:
+        - pod-template-hash
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
         whenUnsatisfiable: ScheduleAnyway

--- a/pkg/manifests/fixtures/nginx/v1.11.2/full-with-http-disabled.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.11.2/full-with-http-disabled.yaml
@@ -421,6 +421,8 @@ spec:
       - labelSelector:
           matchLabels:
             app: nginx
+        matchLabelKeys:
+        - pod-template-hash
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
         whenUnsatisfiable: ScheduleAnyway

--- a/pkg/manifests/fixtures/nginx/v1.11.2/full-with-replicas.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.11.2/full-with-replicas.yaml
@@ -426,6 +426,8 @@ spec:
       - labelSelector:
           matchLabels:
             app: nginx
+        matchLabelKeys:
+        - pod-template-hash
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
         whenUnsatisfiable: ScheduleAnyway

--- a/pkg/manifests/fixtures/nginx/v1.11.2/full-with-target-cpu.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.11.2/full-with-target-cpu.yaml
@@ -426,6 +426,8 @@ spec:
       - labelSelector:
           matchLabels:
             app: nginx
+        matchLabelKeys:
+        - pod-template-hash
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
         whenUnsatisfiable: ScheduleAnyway

--- a/pkg/manifests/fixtures/nginx/v1.11.2/full.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.11.2/full.yaml
@@ -426,6 +426,8 @@ spec:
       - labelSelector:
           matchLabels:
             app: nginx
+        matchLabelKeys:
+        - pod-template-hash
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
         whenUnsatisfiable: ScheduleAnyway

--- a/pkg/manifests/fixtures/nginx/v1.11.2/internal-with-custom-http-errors-cert-and-service.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.11.2/internal-with-custom-http-errors-cert-and-service.yaml
@@ -426,6 +426,8 @@ spec:
       - labelSelector:
           matchLabels:
             app: nginx
+        matchLabelKeys:
+        - pod-template-hash
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
         whenUnsatisfiable: ScheduleAnyway

--- a/pkg/manifests/fixtures/nginx/v1.11.2/internal-with-custom-http-errors.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.11.2/internal-with-custom-http-errors.yaml
@@ -424,6 +424,8 @@ spec:
       - labelSelector:
           matchLabels:
             app: nginx
+        matchLabelKeys:
+        - pod-template-hash
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
         whenUnsatisfiable: ScheduleAnyway

--- a/pkg/manifests/fixtures/nginx/v1.11.2/internal-with-default-backend-service-and-ssl-cert.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.11.2/internal-with-default-backend-service-and-ssl-cert.yaml
@@ -426,6 +426,8 @@ spec:
       - labelSelector:
           matchLabels:
             app: nginx
+        matchLabelKeys:
+        - pod-template-hash
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
         whenUnsatisfiable: ScheduleAnyway

--- a/pkg/manifests/fixtures/nginx/v1.11.2/internal-with-default-backend-service.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.11.2/internal-with-default-backend-service.yaml
@@ -425,6 +425,8 @@ spec:
       - labelSelector:
           matchLabels:
             app: nginx
+        matchLabelKeys:
+        - pod-template-hash
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
         whenUnsatisfiable: ScheduleAnyway

--- a/pkg/manifests/fixtures/nginx/v1.11.2/internal-with-http-disabled.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.11.2/internal-with-http-disabled.yaml
@@ -419,6 +419,8 @@ spec:
       - labelSelector:
           matchLabels:
             app: nginx
+        matchLabelKeys:
+        - pod-template-hash
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
         whenUnsatisfiable: ScheduleAnyway

--- a/pkg/manifests/fixtures/nginx/v1.11.2/internal-with-nil-ssl-cert-and-force-ssl.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.11.2/internal-with-nil-ssl-cert-and-force-ssl.yaml
@@ -424,6 +424,8 @@ spec:
       - labelSelector:
           matchLabels:
             app: nginx
+        matchLabelKeys:
+        - pod-template-hash
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
         whenUnsatisfiable: ScheduleAnyway

--- a/pkg/manifests/fixtures/nginx/v1.11.2/internal-with-ssl-cert-and-force-ssl.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.11.2/internal-with-ssl-cert-and-force-ssl.yaml
@@ -425,6 +425,8 @@ spec:
       - labelSelector:
           matchLabels:
             app: nginx
+        matchLabelKeys:
+        - pod-template-hash
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
         whenUnsatisfiable: ScheduleAnyway

--- a/pkg/manifests/fixtures/nginx/v1.11.2/internal-with-ssl-cert.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.11.2/internal-with-ssl-cert.yaml
@@ -425,6 +425,8 @@ spec:
       - labelSelector:
           matchLabels:
             app: nginx
+        matchLabelKeys:
+        - pod-template-hash
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
         whenUnsatisfiable: ScheduleAnyway

--- a/pkg/manifests/fixtures/nginx/v1.11.2/internal.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.11.2/internal.yaml
@@ -424,6 +424,8 @@ spec:
       - labelSelector:
           matchLabels:
             app: nginx
+        matchLabelKeys:
+        - pod-template-hash
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
         whenUnsatisfiable: ScheduleAnyway

--- a/pkg/manifests/fixtures/nginx/v1.11.2/kube-system.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.11.2/kube-system.yaml
@@ -416,6 +416,8 @@ spec:
       - labelSelector:
           matchLabels:
             app: nginx
+        matchLabelKeys:
+        - pod-template-hash
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
         whenUnsatisfiable: ScheduleAnyway

--- a/pkg/manifests/fixtures/nginx/v1.11.2/no-ownership.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.11.2/no-ownership.yaml
@@ -426,6 +426,8 @@ spec:
       - labelSelector:
           matchLabels:
             app: nginx
+        matchLabelKeys:
+        - pod-template-hash
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
         whenUnsatisfiable: ScheduleAnyway

--- a/pkg/manifests/fixtures/nginx/v1.11.2/optional-features-disabled.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.11.2/optional-features-disabled.yaml
@@ -423,6 +423,8 @@ spec:
       - labelSelector:
           matchLabels:
             app: nginx
+        matchLabelKeys:
+        - pod-template-hash
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
         whenUnsatisfiable: ScheduleAnyway

--- a/pkg/manifests/nginx.go
+++ b/pkg/manifests/nginx.go
@@ -437,6 +437,11 @@ func newNginxIngressControllerDeployment(conf *config.Config, ingressConfig *Ngi
 							TopologyKey:       "kubernetes.io/hostname", // spread across nodes
 							WhenUnsatisfiable: corev1.ScheduleAnyway,
 							LabelSelector:     selector,
+							MatchLabelKeys: []string{
+								// https://kubernetes.io/blog/2024/08/16/matchlabelkeys-podaffinity/
+								// evaluate only pods of the same version (mostly applicable to rollouts)
+								"pod-template-hash",
+							},
 						},
 					},
 					ServiceAccountName: ingressConfig.ResourceName,


### PR DESCRIPTION
# Description

respects rollouts in ingress controller topology spread. Without this, during new rollouts pods aren't necessarily spread out across all nodes because older versions of the deployment pods exist and interfere with calculations then are removed.