### PR TITLE
fix externaldns crds controller gen errors

### DIFF
--- a/api/v1alpha1/clusterexternaldns_types.go
+++ b/api/v1alpha1/clusterexternaldns_types.go
@@ -58,8 +58,6 @@ type ClusterExternalDNSSpec struct {
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinItems:=1
 	// +kubebuilder:validation:MaxItems:=7
-	// +kubebuilder:validation:items:UniqueItems:=true
-	// +kubebuilder:validation:items:MaxProperties:=1
 	// +kubebuilder:validation:XValidation:rule="self.all(item, item.split('/')[2] == self[0].split('/')[2])",message="all items must have the same subscription ID"
 	// +kubebuilder:validation:XValidation:rule="self.all(item, item.split('/')[4] == self[0].split('/')[4])",message="all items must have the same resource group"
 	// +kubebuilder:validation:XValidation:rule="self.all(item, item.split('/')[7] == self[0].split('/')[7])",message="all items must be of the same resource type"
@@ -108,21 +106,27 @@ type ClusterExternalDNSList struct {
 func (c *ClusterExternalDNS) GetTenantId() string {
 	return c.Spec.TenantID
 }
+
 func (c *ClusterExternalDNS) GetInputServiceAccount() string {
 	return c.Spec.Identity.ServiceAccount
 }
+
 func (c *ClusterExternalDNS) GetResourceNamespace() string {
 	return c.Spec.ResourceNamespace
 }
+
 func (c *ClusterExternalDNS) GetInputResourceName() string {
 	return c.Spec.ResourceName
 }
+
 func (c *ClusterExternalDNS) GetResourceTypes() []string {
 	return c.Spec.ResourceTypes
 }
+
 func (c *ClusterExternalDNS) GetDnsZoneresourceIDs() []string {
 	return c.Spec.DNSZoneResourceIDs
 }
+
 func (c *ClusterExternalDNS) GetFilters() *ExternalDNSFilters {
 	return c.Spec.Filters
 }

--- a/api/v1alpha1/externaldns_types.go
+++ b/api/v1alpha1/externaldns_types.go
@@ -65,8 +65,6 @@ type ExternalDNSSpec struct {
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinItems:=1
 	// +kubebuilder:validation:MaxItems:=7
-	// +kubebuilder:validation:items:UniqueItems:=true
-	// +kubebuilder:validation:items:MaxProperties:=1
 	// +kubebuilder:validation:XValidation:rule="self.all(item, item.split('/')[2] == self[0].split('/')[2])",message="all items must have the same subscription ID"
 	// +kubebuilder:validation:XValidation:rule="self.all(item, item.split('/')[4] == self[0].split('/')[4])",message="all items must have the same resource group"
 	// +kubebuilder:validation:XValidation:rule="self.all(item, item.split('/')[7] == self[0].split('/')[7])",message="all items must be of the same resource type"
@@ -149,21 +147,27 @@ type ExternalDNSList struct {
 func (e *ExternalDNS) GetTenantId() string {
 	return e.Spec.TenantID
 }
+
 func (e *ExternalDNS) GetInputServiceAccount() string {
 	return e.Spec.Identity.ServiceAccount
 }
+
 func (e *ExternalDNS) GetResourceNamespace() string {
 	return e.Namespace
 }
+
 func (e *ExternalDNS) GetInputResourceName() string {
 	return e.Spec.ResourceName
 }
+
 func (e *ExternalDNS) GetResourceTypes() []string {
 	return e.Spec.ResourceTypes
 }
+
 func (e *ExternalDNS) GetDnsZoneresourceIDs() []string {
 	return e.Spec.DNSZoneResourceIDs
 }
+
 func (e *ExternalDNS) GetFilters() *ExternalDNSFilters {
 	return e.Spec.Filters
 }

--- a/testing/e2e/manifests/operator.go
+++ b/testing/e2e/manifests/operator.go
@@ -26,7 +26,7 @@ var (
 	}
 
 	// AllUsedOperatorVersions is a list of all the operator versions used today
-	AllUsedOperatorVersions = []OperatorVersion{OperatorVersion0_2_3_Patch_2, OperatorVersionLatest}
+	AllUsedOperatorVersions = []OperatorVersion{OperatorVersion0_2_3_Patch_5, OperatorVersionLatest}
 
 	// AllDnsZoneCounts is a list of all the dns zone counts
 	AllDnsZoneCounts     = []DnsZoneCount{DnsZoneCountNone, DnsZoneCountOne, DnsZoneCountMultiple}
@@ -39,8 +39,8 @@ var (
 type OperatorVersion uint
 
 const (
-	OperatorVersion0_2_1_Patch_4 OperatorVersion = iota // use iota to number with earlier versions being lower numbers
-	OperatorVersion0_2_3_Patch_2
+	OperatorVersion0_2_1_Patch_7 OperatorVersion = iota // use iota to number with earlier versions being lower numbers
+	OperatorVersion0_2_3_Patch_5
 
 	// OperatorVersionLatest represents the latest version of the operator which is essentially whatever code changes this test is running against
 	OperatorVersionLatest = math.MaxUint // this must always be the last/largest value in the enum because we order by value
@@ -48,10 +48,10 @@ const (
 
 func (o OperatorVersion) String() string {
 	switch o {
-	case OperatorVersion0_2_1_Patch_4:
-		return "0.2.1-patch-4"
-	case OperatorVersion0_2_3_Patch_2:
-		return "0.2.3-patch-2"
+	case OperatorVersion0_2_1_Patch_7:
+		return "0.2.1-patch-7"
+	case OperatorVersion0_2_3_Patch_5:
+		return "0.2.3-patch-5"
 	case OperatorVersionLatest:
 		return "latest"
 	default:
@@ -100,10 +100,10 @@ type OperatorConfig struct {
 
 func (o *OperatorConfig) image(latestImage string) string {
 	switch o.Version {
-	case OperatorVersion0_2_1_Patch_4:
-		return "mcr.microsoft.com/aks/aks-app-routing-operator:0.2.1-patch-4"
-	case OperatorVersion0_2_3_Patch_2:
-		return "mcr.microsoft.com/aks/aks-app-routing-operator:0.2.3-patch-2"
+	case OperatorVersion0_2_1_Patch_7:
+		return "mcr.microsoft.com/aks/aks-app-routing-operator:0.2.1-patch-7"
+	case OperatorVersion0_2_3_Patch_5:
+		return "mcr.microsoft.com/aks/aks-app-routing-operator:0.2.3-patch-5"
 	case OperatorVersionLatest:
 		return latestImage
 	default:


### PR DESCRIPTION
# Description

fixes problems with externaldns crds that controller gen errors for

/home/kingoliver/go/src/github.com/Azure/aks-app-routing-operator/api/v1alpha1/clusterexternaldns_types.go:67:2: must apply uniqueitems to an array
/home/kingoliver/go/src/github.com/Azure/aks-app-routing-operator/api/v1alpha1/clusterexternaldns_types.go:67:2: must apply maxproperties to an object
/home/kingoliver/go/src/github.com/Azure/aks-app-routing-operator/api/v1alpha1/externaldns_types.go:74:2: must apply uniqueitems to an array
/home/kingoliver/go/src/github.com/Azure/aks-app-routing-operator/api/v1alpha1/externaldns_types.go:74:2: must apply maxproperties to an object