### PR TITLE
update e2e infra to persist for full work day

### DIFF
--- a/testing/e2e/infra/provision.go
+++ b/testing/e2e/infra/provision.go
@@ -44,7 +44,7 @@ func (i *infra) Provision(ctx context.Context, tenantId, subscriptionId, applica
 	}
 
 	var err error
-	ret.ResourceGroup, err = clients.NewResourceGroup(ctx, subscriptionId, i.ResourceGroup, i.Location, clients.DeleteAfterOpt(6*time.Hour))
+	ret.ResourceGroup, err = clients.NewResourceGroup(ctx, subscriptionId, i.ResourceGroup, i.Location, clients.DeleteAfterOpt(9*time.Hour))
 	if err != nil {
 		return Provisioned{}, logger.Error(lgr, fmt.Errorf("creating resource group %s: %w", i.ResourceGroup, err))
 	}


### PR DESCRIPTION
# Description

updates our e2e infrastructure to remain for a full work day. Any failures can be investigated fully and requeued.