### PR TITLE
add end status to gen checkin tests

### DIFF
--- a/.github/workflows/gen.yaml
+++ b/.github/workflows/gen.yaml
@@ -45,3 +45,9 @@ jobs:
          echo "Proto files need to be regenerated. Run \`make proto\` locally and commit the changes."; 
          exit 1;
         fi
+    
+    - if: always()
+      uses: ./.github/actions/end-status
+      with:
+        name: ${{ env.status-name }}
+        ref: ${{ inputs.status_ref }}


### PR DESCRIPTION
# Description

adds end status to generation checking tests. With this we can now PR gate to ensure that all generations have occurred before merging