### PR TITLE
update e2e to use controller name prefix same as name

### DIFF
--- a/testing/e2e/manifests/nginxIngressController.go
+++ b/testing/e2e/manifests/nginxIngressController.go
@@ -16,7 +16,7 @@ func NewNginxIngressController(name, ingressClassName string) *v1alpha1.NginxIng
 		},
 		Spec: v1alpha1.NginxIngressControllerSpec{
 			IngressClassName:     ingressClassName,
-			ControllerNamePrefix: "nginx",
+			ControllerNamePrefix: name,
 		},
 		Status: v1alpha1.NginxIngressControllerStatus{},
 	}


### PR DESCRIPTION
# Description

updates e2e to use controller name prefix same as name. makes it easier to debug for e2e