### PR TITLE
feat: add CPU and memory request fields to NGINX Ingress Controller

### DIFF
--- a/api/v1alpha1/nginxingresscontroller_types.go
+++ b/api/v1alpha1/nginxingresscontroller_types.go
@@ -73,6 +73,19 @@ type NginxIngressControllerSpec struct {
 	// HTTPDisabled is a flag that disables HTTP traffic to the NginxIngressController
 	// +optional
 	HTTPDisabled bool `json:"httpDisabled,omitempty"`
+
+	// CPURequest is the CPU request for the NGINX Ingress Controller. This is used to set the CPU request for the NGINX Ingress Controller deployment.
+	// +kubebuilder:validation:Pattern=`^[0-9]+(m|M|[a-zA-Z]{1})$`
+	// +kubebuilder:default:=500m
+	// +kubebuilder:validation:Required
+	CPURequest string `json:"cpuRequest,omitempty"`
+
+	// MemoryRequest is the memory request for the NGINX Ingress Controller. This is used to set the memory request for the NGINX Ingress Controller deployment.
+	// +kubebuilder:validation:Pattern=`^[0-9]+(Mi|Gi|[a-zA-Z]{1})$`
+	// +kubebuilder:default:=127Mi
+	// +kubebuilder:validation:Required
+
+	MemoryRequest string `json:"memoryRequest,omitempty"`
 }
 
 // DefaultSSLCertificate holds a secret in the form of a secret struct with name and namespace properties or a key vault uri

--- a/pkg/controller/nginxingress/nginx_ingress_controller.go
+++ b/pkg/controller/nginxingress/nginx_ingress_controller.go
@@ -570,6 +570,8 @@ func ToNginxIngressConfig(nic *approutingv1alpha1.NginxIngressController, defaul
 		MinReplicas:                    minReplicas,
 		MaxReplicas:                    maxReplicas,
 		TargetCPUUtilizationPercentage: getTargetCPUUtilizationPercentage(nic),
+		CPURequest: 				    nic.Spec.CPURequest,
+		MemoryRequest: 				    nic.Spec.MemoryRequest,
 	}
 
 	if cert := nic.Spec.DefaultSSLCertificate; cert != nil {

--- a/pkg/manifests/nginx.go
+++ b/pkg/manifests/nginx.go
@@ -474,8 +474,8 @@ func newNginxIngressControllerDeployment(conf *config.Config, ingressConfig *Ngi
 						},
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("500m"),
-								corev1.ResourceMemory: resource.MustParse("127Mi"),
+								corev1.ResourceCPU:    resource.MustParse(ingressConfig.CPURequest),
+								corev1.ResourceMemory: resource.MustParse(ingressConfig.MemoryRequest),
 							},
 						},
 					}), 6))},

--- a/pkg/manifests/types.go
+++ b/pkg/manifests/types.go
@@ -65,6 +65,8 @@ type NginxIngressConfig struct {
 	CustomHTTPErrors      string         // error codes passed to the configmap to configure nginx to send traffic with the specified headers to its defaultbackend service in case of error
 	MinReplicas           int32
 	MaxReplicas           int32
+	CPURequest             string         // CPU request for the Ingress Controller
+	MemoryRequest          string         // Memory request for the Ingress Controller
 	// TargetCPUUtilizationPercentage is the target average CPU utilization of the Ingress Controller
 	TargetCPUUtilizationPercentage int32
 }


### PR DESCRIPTION

# Description
As discussed in #337 and #177, the default CPU request of 500m is excessive—not just for staging environments, but also for some smaller production environments, particularly when multiple replicas are deployed for high availability. To address this, we’ve introduced configurability for CPU and memory resource requests.

## Changes:
- Added cpuRequest and memoryRequest fields to NginxIngressControllerSpec with validation patterns and default values.
- Propagated these fields to the NginxIngressConfig struct and integrated them into the deployment generation logic.
- Updated deployment manifests to use the specified resource requests dynamically.

This change allows users to customize CPU and memory resource requests for the NGINX Ingress Controller directly through the CRD.


Fixes #337

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?
- [ ] Test A


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
