### PR TITLE
add kubernetes.azure.com/set-kube-service-host-fqdn to pods

### DIFF
--- a/pkg/controller/dns/consts_for_test.go
+++ b/pkg/controller/dns/consts_for_test.go
@@ -71,30 +71,32 @@ var clusterHappyPathPublic = &v1alpha1.ClusterExternalDNS{
 	},
 }
 
-var happyPathPublicJSON = `{"cloud":"","location":"","resourceGroup":"test-rg","subscriptionId":"12345678-1234-1234-1234-123456789012","tenantId":"12345678-1234-1234-1234-123456789012","useWorkloadIdentityExtension":true}`
-var happyPathPublicJSONHash = sha256.Sum256([]byte(happyPathPublicJSON))
-var happyPathPublicNoTenantIDJSON = `{"cloud":"","location":"","resourceGroup":"test-rg","subscriptionId":"12345678-1234-1234-1234-123456789012","tenantId":"12345678-1234-1234-1234-012987654321","useWorkloadIdentityExtension":true}`
-var happyPathPublicNoTenantIDJSONHash = sha256.Sum256([]byte(happyPathPublicNoTenantIDJSON))
-var happyPathPublicConfigmap = &corev1.ConfigMap{
-	TypeMeta: metav1.TypeMeta{
-		Kind:       "ConfigMap",
-		APIVersion: "v1",
-	},
-	ObjectMeta: metav1.ObjectMeta{
-		ResourceVersion: "1",
-		Name:            "happy-path-public-external-dns",
-		Namespace:       "test-ns",
-		Labels: map[string]string{
-			"app.kubernetes.io/managed-by":   "aks-app-routing-operator",
-			"app.kubernetes.io/name":         "happy-path-public-external-dns",
-			"kubernetes.azure.com/managedby": "aks",
+var (
+	happyPathPublicJSON               = `{"cloud":"","location":"","resourceGroup":"test-rg","subscriptionId":"12345678-1234-1234-1234-123456789012","tenantId":"12345678-1234-1234-1234-123456789012","useWorkloadIdentityExtension":true}`
+	happyPathPublicJSONHash           = sha256.Sum256([]byte(happyPathPublicJSON))
+	happyPathPublicNoTenantIDJSON     = `{"cloud":"","location":"","resourceGroup":"test-rg","subscriptionId":"12345678-1234-1234-1234-123456789012","tenantId":"12345678-1234-1234-1234-012987654321","useWorkloadIdentityExtension":true}`
+	happyPathPublicNoTenantIDJSONHash = sha256.Sum256([]byte(happyPathPublicNoTenantIDJSON))
+	happyPathPublicConfigmap          = &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ConfigMap",
+			APIVersion: "v1",
 		},
-		OwnerReferences: ownerReferencesFromCRD(happyPathPublic),
-	},
-	Data: map[string]string{
-		"azure.json": happyPathPublicJSON,
-	},
-}
+		ObjectMeta: metav1.ObjectMeta{
+			ResourceVersion: "1",
+			Name:            "happy-path-public-external-dns",
+			Namespace:       "test-ns",
+			Labels: map[string]string{
+				"app.kubernetes.io/managed-by":   "aks-app-routing-operator",
+				"app.kubernetes.io/name":         "happy-path-public-external-dns",
+				"kubernetes.azure.com/managedby": "aks",
+			},
+			OwnerReferences: ownerReferencesFromCRD(happyPathPublic),
+		},
+		Data: map[string]string{
+			"azure.json": happyPathPublicJSON,
+		},
+	}
+)
 
 var happyPathPublicDeployment = &appsv1.Deployment{
 	TypeMeta: metav1.TypeMeta{
@@ -112,7 +114,8 @@ var happyPathPublicDeployment = &appsv1.Deployment{
 		Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "happy-path-public-external-dns"}},
 		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
-				Labels: map[string]string{"app.kubernetes.io/managed-by": "aks-app-routing-operator", "kubernetes.azure.com/managedby": "aks", "app": "happy-path-public-external-dns", "checksum/configmap": hex.EncodeToString(happyPathPublicJSONHash[:])[:16]},
+				Labels:      map[string]string{"app.kubernetes.io/managed-by": "aks-app-routing-operator", "kubernetes.azure.com/managedby": "aks", "app": "happy-path-public-external-dns", "checksum/configmap": hex.EncodeToString(happyPathPublicJSONHash[:])[:16]},
+				Annotations: map[string]string{"kubernetes.azure.com/set-kube-service-host-fqdn": "true"},
 			},
 			Spec: corev1.PodSpec{
 				ServiceAccountName: testServiceAccount.Name,
@@ -292,7 +295,8 @@ var happyPathPrivateDeployment = &appsv1.Deployment{
 		Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "happy-path-private-external-dns"}},
 		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
-				Labels: map[string]string{"app.kubernetes.io/managed-by": "aks-app-routing-operator", "kubernetes.azure.com/managedby": "aks", "app": "happy-path-private-external-dns", "checksum/configmap": hex.EncodeToString(happyPathPublicJSONHash[:])[:16]},
+				Labels:      map[string]string{"app.kubernetes.io/managed-by": "aks-app-routing-operator", "kubernetes.azure.com/managedby": "aks", "app": "happy-path-private-external-dns", "checksum/configmap": hex.EncodeToString(happyPathPublicJSONHash[:])[:16]},
+				Annotations: map[string]string{"kubernetes.azure.com/set-kube-service-host-fqdn": "true"},
 			},
 			Spec: corev1.PodSpec{
 				ServiceAccountName: testServiceAccount.Name,
@@ -370,7 +374,8 @@ var clusterHappyPathPublicDeployment = &appsv1.Deployment{
 		Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "cluster-happy-path-public-external-dns"}},
 		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
-				Labels: map[string]string{"app.kubernetes.io/managed-by": "aks-app-routing-operator", "kubernetes.azure.com/managedby": "aks", "app": "cluster-happy-path-public-external-dns", "checksum/configmap": hex.EncodeToString(happyPathPublicJSONHash[:])[:16]},
+				Labels:      map[string]string{"app.kubernetes.io/managed-by": "aks-app-routing-operator", "kubernetes.azure.com/managedby": "aks", "app": "cluster-happy-path-public-external-dns", "checksum/configmap": hex.EncodeToString(happyPathPublicJSONHash[:])[:16]},
+				Annotations: map[string]string{"kubernetes.azure.com/set-kube-service-host-fqdn": "true"},
 			},
 			Spec: corev1.PodSpec{
 				ServiceAccountName: testBadServiceAccountInResourceNs.Name,
@@ -549,7 +554,8 @@ var clusterHappyPathPrivateDeployment = &appsv1.Deployment{
 		Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "cluster-happy-path-private-external-dns"}},
 		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
-				Labels: map[string]string{"app.kubernetes.io/managed-by": "aks-app-routing-operator", "kubernetes.azure.com/managedby": "aks", "app": "cluster-happy-path-private-external-dns", "checksum/configmap": hex.EncodeToString(happyPathPublicJSONHash[:])[:16]},
+				Labels:      map[string]string{"app.kubernetes.io/managed-by": "aks-app-routing-operator", "kubernetes.azure.com/managedby": "aks", "app": "cluster-happy-path-private-external-dns", "checksum/configmap": hex.EncodeToString(happyPathPublicJSONHash[:])[:16]},
+				Annotations: map[string]string{"kubernetes.azure.com/set-kube-service-host-fqdn": "true"},
 			},
 			Spec: corev1.PodSpec{
 				ServiceAccountName: testServiceAccountInResourceNs.Name,
@@ -643,24 +649,26 @@ var testBadServiceAccountInResourceNs = &corev1.ServiceAccount{
 }
 
 func ownerReferencesFromCRD(obj *v1alpha1.ExternalDNS) []metav1.OwnerReference {
-	return []metav1.OwnerReference{{
-		APIVersion: obj.APIVersion,
-		Controller: util.ToPtr(true),
-		Kind:       obj.Kind,
-		Name:       obj.Name,
-		UID:        obj.UID,
-	},
+	return []metav1.OwnerReference{
+		{
+			APIVersion: obj.APIVersion,
+			Controller: util.ToPtr(true),
+			Kind:       obj.Kind,
+			Name:       obj.Name,
+			UID:        obj.UID,
+		},
 	}
 }
 
 func ownerReferencesFromClusterCRD(obj *v1alpha1.ClusterExternalDNS) []metav1.OwnerReference {
-	return []metav1.OwnerReference{{
-		APIVersion: obj.APIVersion,
-		Controller: util.ToPtr(true),
-		Kind:       obj.Kind,
-		Name:       obj.Name,
-		UID:        obj.UID,
-	},
+	return []metav1.OwnerReference{
+		{
+			APIVersion: obj.APIVersion,
+			Controller: util.ToPtr(true),
+			Kind:       obj.Kind,
+			Name:       obj.Name,
+			UID:        obj.UID,
+		},
 	}
 }
 

--- a/pkg/manifests/external_dns.go
+++ b/pkg/manifests/external_dns.go
@@ -75,7 +75,6 @@ func (rt ResourceType) generateResourceDeploymentArgs() []string {
 	default:
 		return []string{"--source=ingress"}
 	}
-
 }
 
 func (rt ResourceType) generateRBACRules(dnsconfig *ExternalDnsConfig) []rbacv1.PolicyRule {
@@ -591,6 +590,11 @@ func newExternalDNSDeployment(conf *config.Config, externalDnsConfig *ExternalDn
 			Selector:             &metav1.LabelSelector{MatchLabels: map[string]string{"app": externalDnsConfig.resourceName}},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						// https://learn.microsoft.com/en-us/azure/aks/outbound-rules-control-egress#required-outbound-network-rules-and-fqdns-for-aks-clusters
+						// helps with firewalls blocking communication to api server
+						"kubernetes.azure.com/set-kube-service-host-fqdn": "true",
+					},
 					Labels: podLabels,
 				},
 				Spec: *WithPreferSystemNodes(&corev1.PodSpec{

--- a/pkg/manifests/fixtures/external_dns/all-possibilities.yaml
+++ b/pkg/manifests/fixtures/external_dns/all-possibilities.yaml
@@ -108,6 +108,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        kubernetes.azure.com/set-kube-service-host-fqdn: "true"
       creationTimestamp: null
       labels:
         app: external-dns
@@ -301,6 +303,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        kubernetes.azure.com/set-kube-service-host-fqdn: "true"
       creationTimestamp: null
       labels:
         app: external-dns-private
@@ -492,6 +496,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        kubernetes.azure.com/set-kube-service-host-fqdn: "true"
       creationTimestamp: null
       labels:
         app: test-dns-config-external-dns
@@ -684,6 +690,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        kubernetes.azure.com/set-kube-service-host-fqdn: "true"
       creationTimestamp: null
       labels:
         app: test-dns-config-private-external-dns

--- a/pkg/manifests/fixtures/external_dns/full.yaml
+++ b/pkg/manifests/fixtures/external_dns/full.yaml
@@ -108,6 +108,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        kubernetes.azure.com/set-kube-service-host-fqdn: "true"
       creationTimestamp: null
       labels:
         app: external-dns
@@ -301,6 +303,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        kubernetes.azure.com/set-kube-service-host-fqdn: "true"
       creationTimestamp: null
       labels:
         app: external-dns-private

--- a/pkg/manifests/fixtures/external_dns/gateway-and-ingress-crd.yaml
+++ b/pkg/manifests/fixtures/external_dns/gateway-and-ingress-crd.yaml
@@ -115,6 +115,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        kubernetes.azure.com/set-kube-service-host-fqdn: "true"
       creationTimestamp: null
       labels:
         app: test-dns-config-private-external-dns

--- a/pkg/manifests/fixtures/external_dns/gateway-and-ingress-namespace-scoped-crd.yaml
+++ b/pkg/manifests/fixtures/external_dns/gateway-and-ingress-namespace-scoped-crd.yaml
@@ -109,6 +109,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        kubernetes.azure.com/set-kube-service-host-fqdn: "true"
       creationTimestamp: null
       labels:
         app: crd-test-external-dns

--- a/pkg/manifests/fixtures/external_dns/gateway-crd.yaml
+++ b/pkg/manifests/fixtures/external_dns/gateway-crd.yaml
@@ -106,6 +106,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        kubernetes.azure.com/set-kube-service-host-fqdn: "true"
       creationTimestamp: null
       labels:
         app: crd-test-external-dns

--- a/pkg/manifests/fixtures/external_dns/gateway-namespace-scoped-crd.yaml
+++ b/pkg/manifests/fixtures/external_dns/gateway-namespace-scoped-crd.yaml
@@ -100,6 +100,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        kubernetes.azure.com/set-kube-service-host-fqdn: "true"
       creationTimestamp: null
       labels:
         app: test-dns-config-private-external-dns

--- a/pkg/manifests/fixtures/external_dns/ingress-crd.yaml
+++ b/pkg/manifests/fixtures/external_dns/ingress-crd.yaml
@@ -97,6 +97,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        kubernetes.azure.com/set-kube-service-host-fqdn: "true"
       creationTimestamp: null
       labels:
         app: crd-test-external-dns

--- a/pkg/manifests/fixtures/external_dns/no-ownership.yaml
+++ b/pkg/manifests/fixtures/external_dns/no-ownership.yaml
@@ -108,6 +108,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        kubernetes.azure.com/set-kube-service-host-fqdn: "true"
       creationTimestamp: null
       labels:
         app: external-dns

--- a/pkg/manifests/fixtures/external_dns/private-gateway.yaml
+++ b/pkg/manifests/fixtures/external_dns/private-gateway.yaml
@@ -106,6 +106,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        kubernetes.azure.com/set-kube-service-host-fqdn: "true"
       creationTimestamp: null
       labels:
         app: test-dns-config-private-external-dns

--- a/pkg/manifests/fixtures/external_dns/private-ingress-gateway.yaml
+++ b/pkg/manifests/fixtures/external_dns/private-ingress-gateway.yaml
@@ -115,6 +115,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        kubernetes.azure.com/set-kube-service-host-fqdn: "true"
       creationTimestamp: null
       labels:
         app: test-dns-config-private-external-dns

--- a/pkg/manifests/fixtures/external_dns/private.yaml
+++ b/pkg/manifests/fixtures/external_dns/private.yaml
@@ -108,6 +108,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        kubernetes.azure.com/set-kube-service-host-fqdn: "true"
       creationTimestamp: null
       labels:
         app: external-dns-private

--- a/pkg/manifests/fixtures/external_dns/short-sync-interval.yaml
+++ b/pkg/manifests/fixtures/external_dns/short-sync-interval.yaml
@@ -108,6 +108,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        kubernetes.azure.com/set-kube-service-host-fqdn: "true"
       creationTimestamp: null
       labels:
         app: external-dns
@@ -301,6 +303,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        kubernetes.azure.com/set-kube-service-host-fqdn: "true"
       creationTimestamp: null
       labels:
         app: external-dns-private

--- a/pkg/manifests/fixtures/nginx/default_version/full-with-http-disabled.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/full-with-http-disabled.yaml
@@ -319,6 +319,7 @@ spec:
   template:
     metadata:
       annotations:
+        kubernetes.azure.com/set-kube-service-host-fqdn: "true"
         openservicemesh.io/sidecar-injection: disabled
         prometheus.io/port: "10254"
         prometheus.io/scrape: "true"

--- a/pkg/manifests/fixtures/nginx/default_version/full-with-replicas.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/full-with-replicas.yaml
@@ -322,6 +322,7 @@ spec:
   template:
     metadata:
       annotations:
+        kubernetes.azure.com/set-kube-service-host-fqdn: "true"
         openservicemesh.io/sidecar-injection: disabled
         prometheus.io/port: "10254"
         prometheus.io/scrape: "true"

--- a/pkg/manifests/fixtures/nginx/default_version/full-with-target-cpu.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/full-with-target-cpu.yaml
@@ -322,6 +322,7 @@ spec:
   template:
     metadata:
       annotations:
+        kubernetes.azure.com/set-kube-service-host-fqdn: "true"
         openservicemesh.io/sidecar-injection: disabled
         prometheus.io/port: "10254"
         prometheus.io/scrape: "true"

--- a/pkg/manifests/fixtures/nginx/default_version/full.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/full.yaml
@@ -322,6 +322,7 @@ spec:
   template:
     metadata:
       annotations:
+        kubernetes.azure.com/set-kube-service-host-fqdn: "true"
         openservicemesh.io/sidecar-injection: disabled
         prometheus.io/port: "10254"
         prometheus.io/scrape: "true"

--- a/pkg/manifests/fixtures/nginx/default_version/internal-with-custom-http-errors-cert-and-service.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/internal-with-custom-http-errors-cert-and-service.yaml
@@ -320,6 +320,7 @@ spec:
   template:
     metadata:
       annotations:
+        kubernetes.azure.com/set-kube-service-host-fqdn: "true"
         openservicemesh.io/sidecar-injection: disabled
         prometheus.io/port: "10254"
         prometheus.io/scrape: "true"

--- a/pkg/manifests/fixtures/nginx/default_version/internal-with-custom-http-errors.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/internal-with-custom-http-errors.yaml
@@ -320,6 +320,7 @@ spec:
   template:
     metadata:
       annotations:
+        kubernetes.azure.com/set-kube-service-host-fqdn: "true"
         openservicemesh.io/sidecar-injection: disabled
         prometheus.io/port: "10254"
         prometheus.io/scrape: "true"

--- a/pkg/manifests/fixtures/nginx/default_version/internal-with-default-backend-service-and-ssl-cert.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/internal-with-default-backend-service-and-ssl-cert.yaml
@@ -320,6 +320,7 @@ spec:
   template:
     metadata:
       annotations:
+        kubernetes.azure.com/set-kube-service-host-fqdn: "true"
         openservicemesh.io/sidecar-injection: disabled
         prometheus.io/port: "10254"
         prometheus.io/scrape: "true"

--- a/pkg/manifests/fixtures/nginx/default_version/internal-with-default-backend-service.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/internal-with-default-backend-service.yaml
@@ -320,6 +320,7 @@ spec:
   template:
     metadata:
       annotations:
+        kubernetes.azure.com/set-kube-service-host-fqdn: "true"
         openservicemesh.io/sidecar-injection: disabled
         prometheus.io/port: "10254"
         prometheus.io/scrape: "true"

--- a/pkg/manifests/fixtures/nginx/default_version/internal-with-http-disabled.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/internal-with-http-disabled.yaml
@@ -317,6 +317,7 @@ spec:
   template:
     metadata:
       annotations:
+        kubernetes.azure.com/set-kube-service-host-fqdn: "true"
         openservicemesh.io/sidecar-injection: disabled
         prometheus.io/port: "10254"
         prometheus.io/scrape: "true"

--- a/pkg/manifests/fixtures/nginx/default_version/internal-with-nil-ssl-cert-and-force-ssl.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/internal-with-nil-ssl-cert-and-force-ssl.yaml
@@ -320,6 +320,7 @@ spec:
   template:
     metadata:
       annotations:
+        kubernetes.azure.com/set-kube-service-host-fqdn: "true"
         openservicemesh.io/sidecar-injection: disabled
         prometheus.io/port: "10254"
         prometheus.io/scrape: "true"

--- a/pkg/manifests/fixtures/nginx/default_version/internal-with-ssl-cert-and-force-ssl.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/internal-with-ssl-cert-and-force-ssl.yaml
@@ -320,6 +320,7 @@ spec:
   template:
     metadata:
       annotations:
+        kubernetes.azure.com/set-kube-service-host-fqdn: "true"
         openservicemesh.io/sidecar-injection: disabled
         prometheus.io/port: "10254"
         prometheus.io/scrape: "true"

--- a/pkg/manifests/fixtures/nginx/default_version/internal-with-ssl-cert.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/internal-with-ssl-cert.yaml
@@ -320,6 +320,7 @@ spec:
   template:
     metadata:
       annotations:
+        kubernetes.azure.com/set-kube-service-host-fqdn: "true"
         openservicemesh.io/sidecar-injection: disabled
         prometheus.io/port: "10254"
         prometheus.io/scrape: "true"

--- a/pkg/manifests/fixtures/nginx/default_version/internal.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/internal.yaml
@@ -320,6 +320,7 @@ spec:
   template:
     metadata:
       annotations:
+        kubernetes.azure.com/set-kube-service-host-fqdn: "true"
         openservicemesh.io/sidecar-injection: disabled
         prometheus.io/port: "10254"
         prometheus.io/scrape: "true"

--- a/pkg/manifests/fixtures/nginx/default_version/kube-system.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/kube-system.yaml
@@ -312,6 +312,7 @@ spec:
   template:
     metadata:
       annotations:
+        kubernetes.azure.com/set-kube-service-host-fqdn: "true"
         openservicemesh.io/sidecar-injection: disabled
         prometheus.io/port: "10254"
         prometheus.io/scrape: "true"

--- a/pkg/manifests/fixtures/nginx/default_version/no-ownership.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/no-ownership.yaml
@@ -322,6 +322,7 @@ spec:
   template:
     metadata:
       annotations:
+        kubernetes.azure.com/set-kube-service-host-fqdn: "true"
         openservicemesh.io/sidecar-injection: disabled
         prometheus.io/port: "10254"
         prometheus.io/scrape: "true"

--- a/pkg/manifests/fixtures/nginx/default_version/optional-features-disabled.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/optional-features-disabled.yaml
@@ -320,6 +320,7 @@ spec:
   template:
     metadata:
       annotations:
+        kubernetes.azure.com/set-kube-service-host-fqdn: "true"
         prometheus.io/port: "10254"
         prometheus.io/scrape: "true"
       creationTimestamp: null

--- a/pkg/manifests/fixtures/nginx/v1.11.5/full-with-http-disabled.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.11.5/full-with-http-disabled.yaml
@@ -319,6 +319,7 @@ spec:
   template:
     metadata:
       annotations:
+        kubernetes.azure.com/set-kube-service-host-fqdn: "true"
         openservicemesh.io/sidecar-injection: disabled
         prometheus.io/port: "10254"
         prometheus.io/scrape: "true"

--- a/pkg/manifests/fixtures/nginx/v1.11.5/full-with-replicas.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.11.5/full-with-replicas.yaml
@@ -322,6 +322,7 @@ spec:
   template:
     metadata:
       annotations:
+        kubernetes.azure.com/set-kube-service-host-fqdn: "true"
         openservicemesh.io/sidecar-injection: disabled
         prometheus.io/port: "10254"
         prometheus.io/scrape: "true"

--- a/pkg/manifests/fixtures/nginx/v1.11.5/full-with-target-cpu.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.11.5/full-with-target-cpu.yaml
@@ -322,6 +322,7 @@ spec:
   template:
     metadata:
       annotations:
+        kubernetes.azure.com/set-kube-service-host-fqdn: "true"
         openservicemesh.io/sidecar-injection: disabled
         prometheus.io/port: "10254"
         prometheus.io/scrape: "true"

--- a/pkg/manifests/fixtures/nginx/v1.11.5/full.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.11.5/full.yaml
@@ -322,6 +322,7 @@ spec:
   template:
     metadata:
       annotations:
+        kubernetes.azure.com/set-kube-service-host-fqdn: "true"
         openservicemesh.io/sidecar-injection: disabled
         prometheus.io/port: "10254"
         prometheus.io/scrape: "true"

--- a/pkg/manifests/fixtures/nginx/v1.11.5/internal-with-custom-http-errors-cert-and-service.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.11.5/internal-with-custom-http-errors-cert-and-service.yaml
@@ -320,6 +320,7 @@ spec:
   template:
     metadata:
       annotations:
+        kubernetes.azure.com/set-kube-service-host-fqdn: "true"
         openservicemesh.io/sidecar-injection: disabled
         prometheus.io/port: "10254"
         prometheus.io/scrape: "true"

--- a/pkg/manifests/fixtures/nginx/v1.11.5/internal-with-custom-http-errors.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.11.5/internal-with-custom-http-errors.yaml
@@ -320,6 +320,7 @@ spec:
   template:
     metadata:
       annotations:
+        kubernetes.azure.com/set-kube-service-host-fqdn: "true"
         openservicemesh.io/sidecar-injection: disabled
         prometheus.io/port: "10254"
         prometheus.io/scrape: "true"

--- a/pkg/manifests/fixtures/nginx/v1.11.5/internal-with-default-backend-service-and-ssl-cert.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.11.5/internal-with-default-backend-service-and-ssl-cert.yaml
@@ -320,6 +320,7 @@ spec:
   template:
     metadata:
       annotations:
+        kubernetes.azure.com/set-kube-service-host-fqdn: "true"
         openservicemesh.io/sidecar-injection: disabled
         prometheus.io/port: "10254"
         prometheus.io/scrape: "true"

--- a/pkg/manifests/fixtures/nginx/v1.11.5/internal-with-default-backend-service.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.11.5/internal-with-default-backend-service.yaml
@@ -320,6 +320,7 @@ spec:
   template:
     metadata:
       annotations:
+        kubernetes.azure.com/set-kube-service-host-fqdn: "true"
         openservicemesh.io/sidecar-injection: disabled
         prometheus.io/port: "10254"
         prometheus.io/scrape: "true"

--- a/pkg/manifests/fixtures/nginx/v1.11.5/internal-with-http-disabled.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.11.5/internal-with-http-disabled.yaml
@@ -317,6 +317,7 @@ spec:
   template:
     metadata:
       annotations:
+        kubernetes.azure.com/set-kube-service-host-fqdn: "true"
         openservicemesh.io/sidecar-injection: disabled
         prometheus.io/port: "10254"
         prometheus.io/scrape: "true"

--- a/pkg/manifests/fixtures/nginx/v1.11.5/internal-with-nil-ssl-cert-and-force-ssl.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.11.5/internal-with-nil-ssl-cert-and-force-ssl.yaml
@@ -320,6 +320,7 @@ spec:
   template:
     metadata:
       annotations:
+        kubernetes.azure.com/set-kube-service-host-fqdn: "true"
         openservicemesh.io/sidecar-injection: disabled
         prometheus.io/port: "10254"
         prometheus.io/scrape: "true"

--- a/pkg/manifests/fixtures/nginx/v1.11.5/internal-with-ssl-cert-and-force-ssl.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.11.5/internal-with-ssl-cert-and-force-ssl.yaml
@@ -320,6 +320,7 @@ spec:
   template:
     metadata:
       annotations:
+        kubernetes.azure.com/set-kube-service-host-fqdn: "true"
         openservicemesh.io/sidecar-injection: disabled
         prometheus.io/port: "10254"
         prometheus.io/scrape: "true"

--- a/pkg/manifests/fixtures/nginx/v1.11.5/internal-with-ssl-cert.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.11.5/internal-with-ssl-cert.yaml
@@ -320,6 +320,7 @@ spec:
   template:
     metadata:
       annotations:
+        kubernetes.azure.com/set-kube-service-host-fqdn: "true"
         openservicemesh.io/sidecar-injection: disabled
         prometheus.io/port: "10254"
         prometheus.io/scrape: "true"

--- a/pkg/manifests/fixtures/nginx/v1.11.5/internal.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.11.5/internal.yaml
@@ -320,6 +320,7 @@ spec:
   template:
     metadata:
       annotations:
+        kubernetes.azure.com/set-kube-service-host-fqdn: "true"
         openservicemesh.io/sidecar-injection: disabled
         prometheus.io/port: "10254"
         prometheus.io/scrape: "true"

--- a/pkg/manifests/fixtures/nginx/v1.11.5/kube-system.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.11.5/kube-system.yaml
@@ -312,6 +312,7 @@ spec:
   template:
     metadata:
       annotations:
+        kubernetes.azure.com/set-kube-service-host-fqdn: "true"
         openservicemesh.io/sidecar-injection: disabled
         prometheus.io/port: "10254"
         prometheus.io/scrape: "true"

--- a/pkg/manifests/fixtures/nginx/v1.11.5/no-ownership.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.11.5/no-ownership.yaml
@@ -322,6 +322,7 @@ spec:
   template:
     metadata:
       annotations:
+        kubernetes.azure.com/set-kube-service-host-fqdn: "true"
         openservicemesh.io/sidecar-injection: disabled
         prometheus.io/port: "10254"
         prometheus.io/scrape: "true"

--- a/pkg/manifests/fixtures/nginx/v1.11.5/optional-features-disabled.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.11.5/optional-features-disabled.yaml
@@ -320,6 +320,7 @@ spec:
   template:
     metadata:
       annotations:
+        kubernetes.azure.com/set-kube-service-host-fqdn: "true"
         prometheus.io/port: "10254"
         prometheus.io/scrape: "true"
       creationTimestamp: null

--- a/pkg/manifests/nginx.go
+++ b/pkg/manifests/nginx.go
@@ -383,7 +383,11 @@ func newNginxIngressControllerDeployment(conf *config.Config, ingressConfig *Ngi
 		ingressControllerPodLabels[k] = v
 	}
 
-	podAnnotations := map[string]string{}
+	podAnnotations := map[string]string{
+		// https://learn.microsoft.com/en-us/azure/aks/outbound-rules-control-egress#required-outbound-network-rules-and-fqdns-for-aks-clusters
+		// helps with firewalls blocking communication to api server
+		"kubernetes.azure.com/set-kube-service-host-fqdn": "true",
+	}
 	if !conf.DisableOSM {
 		podAnnotations["openservicemesh.io/sidecar-injection"] = "disabled"
 	}

--- a/pkg/manifests/nginx_test.go
+++ b/pkg/manifests/nginx_test.go
@@ -455,17 +455,11 @@ func TestIngressControllerResources(t *testing.T) {
 	}
 
 	for _, tc := range controllerTestCases {
-		for _, version := range nginxVersions {
-			t.Run(
-				func() string {
-					if version == nil {
-						return tc.Name + "-unspecified"
-					}
-					return tc.Name + version.name
-				}(),
-				func(t *testing.T) {
-					t.Parallel()
-
+		tc := tc
+		t.Run(
+			tc.Name,
+			func(t *testing.T) {
+				for _, version := range nginxVersions {
 					tc.IngConfig.Version = version
 					objs := GetNginxResources(tc.Conf, tc.IngConfig)
 
@@ -476,8 +470,8 @@ func TestIngressControllerResources(t *testing.T) {
 					fixture := path.Join("fixtures", "nginx", versionName, tc.Name) + ".yaml"
 					AssertFixture(t, fixture, objs.Objects())
 					GatekeeperTest(t, fixture, nginxExceptions...)
-				})
-		}
+				}
+			})
 	}
 }
 


### PR DESCRIPTION
# Description

adds kubernetes.azure.com/set-kube-service-host-fqdn annotation to pods. https://learn.microsoft.com/en-us/azure/aks/outbound-rules-control-egress#required-outbound-network-rules-and-fqdns-for-aks-clusters

This helps prevent firewalls from interfering with our pods communicating with the api server.