### PR TITLE
bump setup go

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           ref: ${{ inputs.checkout_ref }}
-      - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: '~1.23'
           cache-dependency-path: "**/*.sum"

--- a/.github/workflows/provision-test.yaml
+++ b/.github/workflows/provision-test.yaml
@@ -18,7 +18,7 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
 
-      - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: '~1.23'
           cache-dependency-path: "**/*.sum"
@@ -47,7 +47,7 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
 
-      - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: '~1.23'
           cache-dependency-path: "**/*.sum"

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -26,7 +26,7 @@ jobs:
         name: ${{ env.status-name }}
         ref: ${{ inputs.status_ref }}
       
-    - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
+    - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version: '~1.23'
         cache-dependency-path: "**/*.sum"


### PR DESCRIPTION
# Description

bumps setup go. We are seeing some caching issues which is slowing our testing pipelines.

https://github.com/Azure/aks-app-routing-operator/actions/runs/15353904775

Failed to restore: getCacheEntry failed: connect ETIMEDOUT 52.152.245.137:443

This bump should fix this