### PR TITLE
enable oidc in e2e clusters

### DIFF
--- a/testing/e2e/clients/aks.go
+++ b/testing/e2e/clients/aks.go
@@ -155,6 +155,9 @@ func NewAks(ctx context.Context, subscriptionId, resourceGroup, name, location s
 					},
 				},
 			},
+			OidcIssuerProfile: &armcontainerservice.ManagedClusterOIDCIssuerProfile{
+				Enabled: to.Ptr(true),
+			},
 		},
 	}
 


### PR DESCRIPTION
# Description

enables oidc in e2e clusters so we can test workload identity