### PR TITLE
Remove disabled CRDs on operator startup to align cluster state with configuration

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -146,6 +146,11 @@ func NewManagerForRestConfig(conf *config.Config, rc *rest.Config) (ctrl.Manager
 		return nil, fmt.Errorf("creating non-caching client: %w", err)
 	}
 
+	if err := removeDisabledCRDs(cl, conf, setupLog); err != nil {
+		setupLog.Error(err, "failed to remove disabled CRDs")
+		return nil, fmt.Errorf("removing disabled CRDs: %w", err)
+	}
+
 	if err := loadCRDs(cl, conf, setupLog); err != nil {
 		setupLog.Error(err, "failed to load CRDs")
 		return nil, fmt.Errorf("loading CRDs: %w", err)

--- a/pkg/controller/crd.go
+++ b/pkg/controller/crd.go
@@ -24,121 +24,93 @@ const (
 	defaultDomainCertificateCrdFilename = "approuting.kubernetes.azure.com_defaultdomaincertificates.yaml"
 )
 
-// loadCRDs loads the CRDs that should be active based on the current config into the cluster.
-func loadCRDs(c client.Client, cfg *config.Config, log logr.Logger) error {
+// readAllCRDs reads and parses all CRD files from the configured directory, returning them keyed by filename.
+func readAllCRDs(cfg *config.Config, log logr.Logger) (map[string]*apiextensionsv1.CustomResourceDefinition, error) {
 	if cfg == nil {
-		return errors.New("config cannot be nil")
+		return nil, errors.New("config cannot be nil")
 	}
 
 	log = log.WithValues("crdPath", cfg.CrdPath)
-	log.Info("reading crd directory")
 	files, err := os.ReadDir(cfg.CrdPath)
 	if err != nil {
-		return fmt.Errorf("reading crd directory %s: %w", cfg.CrdPath, err)
+		return nil, fmt.Errorf("reading crd directory %s: %w", cfg.CrdPath, err)
 	}
 
-	log.Info("applying crds")
+	crds := make(map[string]*apiextensionsv1.CustomResourceDefinition)
 	for _, file := range files {
 		if file.IsDir() {
 			continue
 		}
 
-		filename := file.Name()
+		path := filepath.Join(cfg.CrdPath, file.Name())
+		log := log.WithValues("path", path)
+		log.Info("reading crd file")
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("reading crd file %s: %w", path, err)
+		}
+
+		crd := &apiextensionsv1.CustomResourceDefinition{}
+		log.Info("unmarshalling crd file")
+		if err := yaml.UnmarshalStrict(content, crd); err != nil {
+			return nil, fmt.Errorf("unmarshalling crd file %s: %w", path, err)
+		}
+		crds[file.Name()] = crd
+	}
+	return crds, nil
+}
+
+// loadCRDs loads the CRDs that should be active based on the current config into the cluster.
+func loadCRDs(c client.Client, cfg *config.Config, log logr.Logger) error {
+	crds, err := readAllCRDs(cfg, log)
+	if err != nil {
+		return err
+	}
+
+	for filename, crd := range crds {
 		if !shouldLoadCRD(cfg, filename) {
 			continue
 		}
-
-		crd, err := readCRDFile(cfg.CrdPath, filename)
-		if err != nil {
-			return err
-		}
-
 		log.Info("upserting crd", "name", crd.Name)
 		if err := util.Upsert(context.Background(), c, crd); err != nil {
 			return fmt.Errorf("upserting crd %s: %w", crd.Name, err)
 		}
 	}
-
-	log.Info("crds loaded")
 	return nil
 }
 
 // removeDisabledCRDs removes CRDs from the cluster that are no longer needed based on the current config.
 func removeDisabledCRDs(c client.Client, cfg *config.Config, log logr.Logger) error {
-	if cfg == nil {
-		return errors.New("config cannot be nil")
-	}
-
-	log = log.WithValues("crdPath", cfg.CrdPath)
-	log.Info("reading crd directory for cleanup")
-	files, err := os.ReadDir(cfg.CrdPath)
+	crds, err := readAllCRDs(cfg, log)
 	if err != nil {
-		return fmt.Errorf("reading crd directory %s: %w", cfg.CrdPath, err)
+		return err
 	}
 
-	for _, file := range files {
-		if file.IsDir() {
-			continue
-		}
-
-		filename := file.Name()
+	for filename, crd := range crds {
 		if !shouldRemoveCRD(cfg, filename) {
 			continue
 		}
-
-		crd, err := readCRDFile(cfg.CrdPath, filename)
-		if err != nil {
-			return err
-		}
-
 		if err := removeCRD(c, crd, log); err != nil {
 			return fmt.Errorf("removing crd %s: %w", crd.Name, err)
 		}
 	}
-
-	log.Info("disabled crds removed")
 	return nil
-}
-
-// readCRDFile reads and unmarshals a CRD YAML file from the given directory.
-func readCRDFile(crdPath, filename string) (*apiextensionsv1.CustomResourceDefinition, error) {
-	path := filepath.Join(crdPath, filename)
-	content, err := os.ReadFile(path)
-	if err != nil {
-		return nil, fmt.Errorf("reading crd file %s: %w", path, err)
-	}
-
-	crd := &apiextensionsv1.CustomResourceDefinition{}
-	if err := yaml.UnmarshalStrict(content, crd); err != nil {
-		return nil, fmt.Errorf("unmarshalling crd file %s: %w", path, err)
-	}
-	return crd, nil
 }
 
 // removeCRD deletes a CRD from the cluster if it exists.
 // This is used to clean up CRDs that were previously installed but are no longer needed.
 func removeCRD(c client.Client, crd *apiextensionsv1.CustomResourceDefinition, log logr.Logger) error {
-
-	log.Info("checking if crd exists in cluster", "name", crd.Name)
-	err := c.Get(context.Background(), client.ObjectKeyFromObject(crd), crd)
-	if apierrors.IsNotFound(err) {
-		log.Info("crd not found, nothing to delete", "name", crd.Name)
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("checking if crd %s exists: %w", crd.Name, err)
-	}
-
-	log.Info("deleting crd", "name", crd.Name)
+	log = log.WithValues("name", crd.Name)
+	log.Info("deleting crd")
 	if err := c.Delete(context.Background(), crd); err != nil {
 		if apierrors.IsNotFound(err) {
-			log.Info("crd already deleted, nothing to do", "name", crd.Name)
+			log.Info("crd already deleted, nothing to do")
 			return nil
 		}
 		return fmt.Errorf("deleting crd %s: %w", crd.Name, err)
 	}
 
-	log.Info("crd deleted successfully", "name", crd.Name)
+	log.Info("crd deleted successfully")
 	return nil
 }
 

--- a/pkg/controller/crd.go
+++ b/pkg/controller/crd.go
@@ -31,6 +31,7 @@ func readAllCRDs(cfg *config.Config, log logr.Logger) (map[string]*apiextensions
 	}
 
 	log = log.WithValues("crdPath", cfg.CrdPath)
+	log.Info("reading crd directory")
 	files, err := os.ReadDir(cfg.CrdPath)
 	if err != nil {
 		return nil, fmt.Errorf("reading crd directory %s: %w", cfg.CrdPath, err)

--- a/pkg/controller/crd.go
+++ b/pkg/controller/crd.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/aks-app-routing-operator/pkg/util"
 	"github.com/go-logr/logr"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 )
@@ -23,7 +24,7 @@ const (
 	defaultDomainCertificateCrdFilename = "approuting.kubernetes.azure.com_defaultdomaincertificates.yaml"
 )
 
-// loadCRDs loads the CRDs from the specified path into the cluster
+// loadCRDs loads the CRDs that should be active based on the current config into the cluster.
 func loadCRDs(c client.Client, cfg *config.Config, log logr.Logger) error {
 	if cfg == nil {
 		return errors.New("config cannot be nil")
@@ -47,22 +48,12 @@ func loadCRDs(c client.Client, cfg *config.Config, log logr.Logger) error {
 			continue
 		}
 
-		path := filepath.Join(cfg.CrdPath, filename)
-		log := log.WithValues("path", path)
-		log.Info("reading crd file")
-		var content []byte
-		content, err := os.ReadFile(path)
+		crd, err := readCRDFile(cfg.CrdPath, filename)
 		if err != nil {
-			return fmt.Errorf("reading crd file %s: %w", path, err)
+			return err
 		}
 
-		log.Info("unmarshalling crd file")
-		crd := &apiextensionsv1.CustomResourceDefinition{}
-		if err := yaml.UnmarshalStrict(content, crd); err != nil {
-			return fmt.Errorf("unmarshalling crd file %s: %w", path, err)
-		}
-
-		log.Info("upserting crd")
+		log.Info("upserting crd", "name", crd.Name)
 		if err := util.Upsert(context.Background(), c, crd); err != nil {
 			return fmt.Errorf("upserting crd %s: %w", crd.Name, err)
 		}
@@ -70,6 +61,92 @@ func loadCRDs(c client.Client, cfg *config.Config, log logr.Logger) error {
 
 	log.Info("crds loaded")
 	return nil
+}
+
+// removeDisabledCRDs removes CRDs from the cluster that are no longer needed based on the current config.
+func removeDisabledCRDs(c client.Client, cfg *config.Config, log logr.Logger) error {
+	if cfg == nil {
+		return errors.New("config cannot be nil")
+	}
+
+	log = log.WithValues("crdPath", cfg.CrdPath)
+	log.Info("reading crd directory for cleanup")
+	files, err := os.ReadDir(cfg.CrdPath)
+	if err != nil {
+		return fmt.Errorf("reading crd directory %s: %w", cfg.CrdPath, err)
+	}
+
+	for _, file := range files {
+		if file.IsDir() {
+			continue
+		}
+
+		filename := file.Name()
+		if !shouldRemoveCRD(cfg, filename) {
+			continue
+		}
+
+		crd, err := readCRDFile(cfg.CrdPath, filename)
+		if err != nil {
+			return err
+		}
+
+		if err := removeCRD(c, crd, log); err != nil {
+			return fmt.Errorf("removing crd %s: %w", crd.Name, err)
+		}
+	}
+
+	log.Info("disabled crds removed")
+	return nil
+}
+
+// readCRDFile reads and unmarshals a CRD YAML file from the given directory.
+func readCRDFile(crdPath, filename string) (*apiextensionsv1.CustomResourceDefinition, error) {
+	path := filepath.Join(crdPath, filename)
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading crd file %s: %w", path, err)
+	}
+
+	crd := &apiextensionsv1.CustomResourceDefinition{}
+	if err := yaml.UnmarshalStrict(content, crd); err != nil {
+		return nil, fmt.Errorf("unmarshalling crd file %s: %w", path, err)
+	}
+	return crd, nil
+}
+
+// removeCRD deletes a CRD from the cluster if it exists.
+// This is used to clean up CRDs that were previously installed but are no longer needed.
+func removeCRD(c client.Client, crd *apiextensionsv1.CustomResourceDefinition, log logr.Logger) error {
+
+	log.Info("checking if crd exists in cluster", "name", crd.Name)
+	err := c.Get(context.Background(), client.ObjectKeyFromObject(crd), crd)
+	if apierrors.IsNotFound(err) {
+		log.Info("crd not found, nothing to delete", "name", crd.Name)
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("checking if crd %s exists: %w", crd.Name, err)
+	}
+
+	log.Info("deleting crd", "name", crd.Name)
+	if err := c.Delete(context.Background(), crd); err != nil {
+		return fmt.Errorf("deleting crd %s: %w", crd.Name, err)
+	}
+
+	log.Info("crd deleted successfully", "name", crd.Name)
+	return nil
+}
+
+// shouldRemoveCRD returns true if the CRD should be actively removed from the cluster.
+// This is the inverse cleanup logic for CRDs that were previously installed but are now disabled.
+func shouldRemoveCRD(cfg *config.Config, filename string) bool {
+	switch filename {
+	case nginxIngresscontrollerCrdFilename:
+		return cfg.DisableIngressNginx
+	default:
+		return false
+	}
 }
 
 func shouldLoadCRD(cfg *config.Config, filename string) bool {

--- a/pkg/controller/crd.go
+++ b/pkg/controller/crd.go
@@ -131,6 +131,10 @@ func removeCRD(c client.Client, crd *apiextensionsv1.CustomResourceDefinition, l
 
 	log.Info("deleting crd", "name", crd.Name)
 	if err := c.Delete(context.Background(), crd); err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Info("crd already deleted, nothing to do", "name", crd.Name)
+			return nil
+		}
 		return fmt.Errorf("deleting crd %s: %w", crd.Name, err)
 	}
 

--- a/pkg/controller/crd_test.go
+++ b/pkg/controller/crd_test.go
@@ -176,3 +176,129 @@ func TestShouldLoadCRD(t *testing.T) {
 		})
 	}
 }
+
+func TestShouldRemoveCRD(t *testing.T) {
+	cases := []struct {
+		name     string
+		cfg      *config.Config
+		filename string
+		expected bool
+	}{
+		{name: "nginx crd with ingress nginx disabled", cfg: ingressNginxDisabled, filename: nginxIngresscontrollerCrdFilename, expected: true},
+		{name: "nginx crd with ingress nginx enabled", cfg: workloadIdentityEnabled, filename: nginxIngresscontrollerCrdFilename, expected: false},
+		{name: "external dns crd with ingress nginx disabled", cfg: ingressNginxDisabled, filename: externalDnsCrdFilename, expected: false},
+		{name: "unknown crd with ingress nginx disabled", cfg: ingressNginxDisabled, filename: "other.crd.yaml", expected: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, shouldRemoveCRD(tc.cfg, tc.filename), "expected correct crd removal behavior")
+		})
+	}
+}
+
+func TestRemoveCRD(t *testing.T) {
+	t.Run("crd exists and is deleted", func(t *testing.T) {
+		existingCrd := &apiextensionsv1.CustomResourceDefinition{}
+		existingCrd.Name = nginxCrdName
+		cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existingCrd).Build()
+
+		crd := &apiextensionsv1.CustomResourceDefinition{}
+		crd.Name = nginxCrdName
+		require.NoError(t, removeCRD(cl, crd, logr.Discard()))
+
+		// verify it's gone
+		err := cl.Get(context.Background(), client.ObjectKeyFromObject(crd), crd)
+		require.Error(t, err, "expected crd to be deleted")
+	})
+
+	t.Run("crd does not exist", func(t *testing.T) {
+		cl := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+		crd := &apiextensionsv1.CustomResourceDefinition{}
+		crd.Name = nginxCrdName
+		require.NoError(t, removeCRD(cl, crd, logr.Discard()))
+	})
+}
+
+func TestRemoveDisabledCRDs(t *testing.T) {
+	t.Run("nginx disabled removes pre-existing nginx crd", func(t *testing.T) {
+		existingCrd := &apiextensionsv1.CustomResourceDefinition{}
+		existingCrd.Name = nginxCrdName
+		cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existingCrd).Build()
+
+		require.NoError(t, removeDisabledCRDs(cl, ingressNginxDisabled, logr.Discard()))
+
+		crd := &apiextensionsv1.CustomResourceDefinition{}
+		crd.Name = nginxCrdName
+		err := cl.Get(context.Background(), client.ObjectKeyFromObject(crd), crd)
+		require.Error(t, err, "expected nginx crd to be removed")
+	})
+
+	t.Run("nginx disabled with workload identity removes nginx only", func(t *testing.T) {
+		existingCrd := &apiextensionsv1.CustomResourceDefinition{}
+		existingCrd.Name = nginxCrdName
+		cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existingCrd).Build()
+
+		require.NoError(t, removeDisabledCRDs(cl, ingressNginxDisabledWorkloadIdentity, logr.Discard()))
+
+		// nginx CRD should be removed
+		crd := &apiextensionsv1.CustomResourceDefinition{}
+		crd.Name = nginxCrdName
+		err := cl.Get(context.Background(), client.ObjectKeyFromObject(crd), crd)
+		require.Error(t, err, "expected nginx crd to be removed")
+	})
+
+	t.Run("nginx disabled but crd was never installed", func(t *testing.T) {
+		cl := fake.NewClientBuilder().WithScheme(scheme).Build()
+		require.NoError(t, removeDisabledCRDs(cl, ingressNginxDisabled, logr.Discard()))
+	})
+
+	t.Run("nil config", func(t *testing.T) {
+		cl := fake.NewClientBuilder().WithScheme(scheme).Build()
+		err := removeDisabledCRDs(cl, nil, logr.Discard())
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "config cannot be nil")
+	})
+
+	t.Run("nginx enabled does not remove nginx crd", func(t *testing.T) {
+		existingCrd := &apiextensionsv1.CustomResourceDefinition{}
+		existingCrd.Name = nginxCrdName
+		cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existingCrd).Build()
+
+		require.NoError(t, removeDisabledCRDs(cl, workloadIdentityEnabled, logr.Discard()))
+
+		crd := &apiextensionsv1.CustomResourceDefinition{}
+		crd.Name = nginxCrdName
+		require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(crd), crd), "expected nginx crd to still exist")
+	})
+}
+
+func TestLoadCRDsAndRemoveDisabledCRDs(t *testing.T) {
+	t.Run("nginx disabled with workload identity removes nginx and installs dns crds", func(t *testing.T) {
+		existingCrd := &apiextensionsv1.CustomResourceDefinition{}
+		existingCrd.Name = nginxCrdName
+		cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existingCrd).Build()
+
+		require.NoError(t, removeDisabledCRDs(cl, ingressNginxDisabledWorkloadIdentity, logr.Discard()))
+		require.NoError(t, loadCRDs(cl, ingressNginxDisabledWorkloadIdentity, logr.Discard()))
+
+		// nginx CRD should be removed
+		crd := &apiextensionsv1.CustomResourceDefinition{}
+		crd.Name = nginxCrdName
+		err := cl.Get(context.Background(), client.ObjectKeyFromObject(crd), crd)
+		require.Error(t, err, "expected nginx crd to be removed")
+
+		// dns CRDs should be installed
+		crds := &apiextensionsv1.CustomResourceDefinitionList{}
+		require.NoError(t, cl.List(context.Background(), crds))
+		seen := map[string]struct{}{}
+		for _, c := range crds.Items {
+			seen[c.Name] = struct{}{}
+		}
+		_, hasExtDns := seen[externalDnsCrdName]
+		_, hasClusterExtDns := seen[clusterExternalDnsCrdName]
+		require.True(t, hasExtDns, "expected external dns crd to be installed")
+		require.True(t, hasClusterExtDns, "expected cluster external dns crd to be installed")
+	})
+}

--- a/pkg/controller/crd_test.go
+++ b/pkg/controller/crd_test.go
@@ -51,6 +51,52 @@ var (
 	ingressNginxDisabledWorkloadIdentity   = &config.Config{DisableIngressNginx: true, EnabledWorkloadIdentity: true, CrdPath: validCrdPath}
 )
 
+func TestReadAllCRDs(t *testing.T) {
+	t.Run("valid path returns all CRDs keyed by filename", func(t *testing.T) {
+		crds, err := readAllCRDs(&config.Config{CrdPath: validCrdPath}, logr.Discard())
+		require.NoError(t, err)
+
+		expectedFiles := []string{
+			externalDnsCrdFilename,
+			clusterExternalDnsCrdFilename,
+			nginxIngresscontrollerCrdFilename,
+			defaultDomainCertificateCrdFilename,
+		}
+		require.Len(t, crds, len(expectedFiles))
+		for _, f := range expectedFiles {
+			crd, ok := crds[f]
+			require.True(t, ok, "expected key %s in map", f)
+			require.NotEmpty(t, crd.Name, "expected CRD name to be populated for %s", f)
+		}
+	})
+
+	t.Run("nil config returns error", func(t *testing.T) {
+		_, err := readAllCRDs(nil, logr.Discard())
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "config cannot be nil")
+	})
+
+	t.Run("non-existent path returns error", func(t *testing.T) {
+		_, err := readAllCRDs(&config.Config{CrdPath: nonExistentFilePath}, logr.Discard())
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "reading crd directory")
+	})
+
+	t.Run("invalid yaml returns unmarshalling error", func(t *testing.T) {
+		_, err := readAllCRDs(&config.Config{CrdPath: nonCrdManifestsPath}, logr.Discard())
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "unmarshalling crd file")
+	})
+
+	t.Run("directories are skipped", func(t *testing.T) {
+		crds, err := readAllCRDs(&config.Config{CrdPath: validCrdPathWithDir}, logr.Discard())
+		require.NoError(t, err)
+		for key := range crds {
+			require.NotContains(t, key, "/", "map keys should be filenames, not directories")
+		}
+	})
+}
+
 func TestLoadCRDs(t *testing.T) {
 	t.Run("valid crds", func(t *testing.T) {
 		cl := fake.NewClientBuilder().WithScheme(scheme).Build()
@@ -271,6 +317,31 @@ func TestRemoveDisabledCRDs(t *testing.T) {
 		crd := &apiextensionsv1.CustomResourceDefinition{}
 		crd.Name = nginxCrdName
 		require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(crd), crd), "expected nginx crd to still exist")
+	})
+
+	t.Run("unrelated crd is not removed when nginx is disabled", func(t *testing.T) {
+		unrelatedCrdName := "unrelated.example.com"
+
+		unrelatedCrd := &apiextensionsv1.CustomResourceDefinition{}
+		unrelatedCrd.Name = unrelatedCrdName
+
+		nginxCrd := &apiextensionsv1.CustomResourceDefinition{}
+		nginxCrd.Name = nginxCrdName
+
+		cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(unrelatedCrd, nginxCrd).Build()
+
+		require.NoError(t, removeDisabledCRDs(cl, ingressNginxDisabled, logr.Discard()))
+
+		// unrelated CRD should still exist
+		crd := &apiextensionsv1.CustomResourceDefinition{}
+		crd.Name = unrelatedCrdName
+		require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(crd), crd), "expected unrelated crd to still exist")
+
+		// nginx CRD should be removed
+		crd = &apiextensionsv1.CustomResourceDefinition{}
+		crd.Name = nginxCrdName
+		err := cl.Get(context.Background(), client.ObjectKeyFromObject(crd), crd)
+		require.Error(t, err, "expected nginx crd to be removed")
 	})
 }
 

--- a/testing/e2e/suites/clusterexternaldns_crd.go
+++ b/testing/e2e/suites/clusterexternaldns_crd.go
@@ -499,7 +499,7 @@ func clusterExternalDnsCrdTests(in infra.Provisioned) []test {
 								},
 							},
 						},
-						expectedError: errors.New("Required value, <nil>: Invalid value: \"null\""),
+						expectedError: errors.New("Required value, <nil>: Invalid value: null"),
 					},
 					{
 						name: "empty resourcetypes",
@@ -668,9 +668,9 @@ func clusterExternalDnsCrdTests(in infra.Provisioned) []test {
 								Name: "no-identity",
 							},
 							Spec: v1alpha1.ClusterExternalDNSSpec{
-								ResourceName:       "test",
-								ResourceNamespace:  clusterExternalDNSTestNamespace,
-								TenantID:           to.Ptr("123e4567-e89b-12d3-a456-426614174000"),
+								ResourceName:      "test",
+								ResourceNamespace: clusterExternalDNSTestNamespace,
+								TenantID:          to.Ptr("123e4567-e89b-12d3-a456-426614174000"),
 								DNSZoneResourceIDs: []string{
 									"/subscriptions/123e4567-e89b-12d3-a456-426614174000/resourceGroups/test/providers/Microsoft.network/dnszones/test",
 									"/subscriptions/123e4567-e89b-12d3-a456-426614174000/resourceGroups/test/providers/Microsoft.network/dnszones/test2",

--- a/testing/e2e/suites/externaldns_crd.go
+++ b/testing/e2e/suites/externaldns_crd.go
@@ -433,7 +433,7 @@ func externalDnsCrdTests(in infra.Provisioned) []test {
 								},
 							},
 						},
-						expectedError: errors.New("Required value, <nil>: Invalid value: \"null\""),
+						expectedError: errors.New("Required value, <nil>: Invalid value: null"),
 					},
 					{
 						name: "empty resourcetypes",


### PR DESCRIPTION
# Description
On startup, the operator now actively removes CRDs that are disabled by the current configuration before loading the active set. This ensures the CRDs present in the cluster stay aligned with the features enabled for the operator, preventing stale CRDs from lingering after a feature is turned off.

Currently this applies to the NginxIngressController CRD when ingress-nginx is disabled (DisableIngressNginx).

Also refactors the CRD file reading logic into a shared readCRDFile helper to reduce duplication between loading and removal paths.

Fixes # (issue)
Feature # (details)

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
- [x] `TestShouldRemoveCRD` — verifies CRD removal decision logic for nginx/external-dns/unknown filenames
- [x] `TestRemoveCRD` — verifies deletion of an existing CRD and no-op when CRD doesn't exist
- [x] `TestRemoveDisabledCRDs` — verifies end-to-end removal flow: nginx disabled removes CRD, nginx enabled preserves CRD, nil config returns error, handles never-installed CRDs gracefully
- [x] `TestLoadCRDsAndRemoveDisabledCRDs` — integration test confirming nginx CRD is removed while DNS CRDs are still installed when nginx is disabled with workload identity

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules