### PR TITLE
fix e2e externaldns validation bug

### DIFF
--- a/testing/e2e/suites/clusterexternaldns_crd.go
+++ b/testing/e2e/suites/clusterexternaldns_crd.go
@@ -499,7 +499,7 @@ func clusterExternalDnsCrdTests(in infra.Provisioned) []test {
 								},
 							},
 						},
-						expectedError: errors.New("Required value, <nil>: Invalid value: \"null\""),
+						expectedError: errors.New("spec.resourceTypes: Required value"),
 					},
 					{
 						name: "empty resourcetypes",

--- a/testing/e2e/suites/externaldns_crd.go
+++ b/testing/e2e/suites/externaldns_crd.go
@@ -433,7 +433,7 @@ func externalDnsCrdTests(in infra.Provisioned) []test {
 								},
 							},
 						},
-						expectedError: errors.New("Required value, <nil>: Invalid value: \"null\""),
+						expectedError: errors.New("spec.resourceTypes: Required value"),
 					},
 					{
 						name: "empty resourcetypes",


### PR DESCRIPTION
# Description

fixes e2e externaldns validation bug. E2es are flaky because of this.

Essentially, the exact error message (with ' vs no quotes) changes based on k8s version.