### PR TITLE
Bump Go to 1.25.9 to fix stdlib CVEs

### DIFF
--- a/docker/dev.Dockerfile
+++ b/docker/dev.Dockerfile
@@ -1,6 +1,6 @@
 # convenience dockerfile for unit tests
 # run make unit from root
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.25.8
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.25.9
 
 WORKDIR /app-routing-operator
 

--- a/docker/e2e.Dockerfile
+++ b/docker/e2e.Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.25.8 AS builder
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.25.9 AS builder
 
 
 WORKDIR /go/src/github.com/Azure/aks-app-routing-operator

--- a/docker/operator.Dockerfile
+++ b/docker/operator.Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.25.8 AS builder
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.25.9 AS builder
 
 WORKDIR /go/src/github.com/Azure/aks-app-routing-operator
 ADD . .

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Azure/aks-app-routing-operator
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.20.0


### PR DESCRIPTION
Fixes CVE-2026-32280, CVE-2026-32281, CVE-2026-32282, CVE-2026-32283, CVE-2026-32288, and CVE-2026-32289 reported by trivy on the operator image build.

