### PR TITLE
default --enable-default-domain-gateway to true

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -59,7 +59,7 @@ func init() {
 	flag.StringVar(&Flags.DefaultDomainServerAddress, "default-domain-server-address", "", "address of the default domain server for the particular cluster app routing operator is deployed in")
 	flag.StringVar(&Flags.DefaultDomainClientID, "default-domain-client-id", "", "client ID of the managed identity with federated permissions to interact with the default domain DNS zone")
 	flag.StringVar(&Flags.DefaultDomainZoneID, "default-domain-zone-id", "", "resource ID of the DNS zone for the default domain")
-	flag.BoolVar(&Flags.EnableDefaultDomainGateway, "enable-default-domain-gateway", false, "enable Gateway API resource type for default domain external DNS (defaults to off)")
+	flag.BoolVar(&Flags.EnableDefaultDomainGateway, "enable-default-domain-gateway", true, "enable Gateway API resource type for default domain external DNS (defaults to on); set to false to restrict default-domain external DNS to Ingress resources only")
 }
 
 func (c *Config) Validate() error {


### PR DESCRIPTION
## Summary

When the default-domain feature is enabled in an AKS cluster that exposes traffic via Gateway API (e.g. with AppRoutingIstio), the managed default-domain ExternalDNS deployment is not publishing DNS records for `HTTPRoute` hostnames. The deployment is started with `--source=ingress` only, so Gateway API resources are invisible to it. End-to-end, default-domain certificate issuance and Gateway/HTTPRoute publication succeed, but the hostname never resolves.

The operator already has full Gateway API support in its ExternalDNS manifest generation — RBAC, `--source=gateway-httproute`/`--source=gateway-grpcroute`, and namespace filters are all wired up. The Gateway resource type was gated behind `--enable-default-domain-gateway` (defaulting to `false`) in `defaultDomainClusterExternalDNS`, leaving the feature off in clusters where it should just work.

This flips the default to `true`. The flag is preserved as an opt-out for callers that need to restrict the default-domain ExternalDNS to Ingress only (e.g. clusters where the Gateway API CRDs are not installed and ExternalDNS startup warnings are undesirable).

## Behavior change

- Before: default-domain ExternalDNS watches `Ingress` only by default. Hostnames published only via Gateway API never get DNS records.
- After: default-domain ExternalDNS watches `Ingress` and Gateway API (`HTTPRoute`/`GRPCRoute`) by default. Hostnames published via either path get DNS records.

## Test plan

- [x] `go test ./pkg/config/...` passes
- [x] `go test ./pkg/controller/dns/...` passes (with `KUBEBUILDER_ASSETS` set via `setup-envtest`)
- [x] `go test ./pkg/manifests/...` passes
- [x] Existing tests in `pkg/controller/dns/default_domain_cluster_external_dns_test.go` already cover both `EnableDefaultDomainGateway: true` and `EnableDefaultDomainGateway: false` cases — they explicitly set the flag value so they do not depend on the default.
- [ ] Verify on a live AKS cluster that DNS records are created for an `HTTPRoute` hostname under the default-domain zone (validated in aks-rp e2e scenario `Scenario_Traffic_AppRouting_DefaultDomain_Istio_HelloWorld`).

## Discovery context

This was discovered while validating the meshless-Istio + default-domain combination via an aks-rp e2e scenario that creates a `Gateway` and `HTTPRoute` against `gatewayClassName=approuting-istio`. The `WaitForDNSRecord` step consistently failed across 5 retries with `lookup ... no such host`, and Kusto telemetry confirmed the ExternalDNS pod startup log line `Sources:[ingress]`.