### PR TITLE
feat(manifests): exclude ns from dynatrace

### DIFF
--- a/pkg/manifests/common.go
+++ b/pkg/manifests/common.go
@@ -61,7 +61,10 @@ func Namespace(conf *config.Config, nsName string) *corev1.Namespace {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: nsName,
 			// don't set top-level labels,namespace is not managed by operator
-			Labels:      map[string]string{},
+			Labels: map[string]string{
+				// opt the namespace out of Dynatrace OneAgent/monitoring injection
+				"dynatrace.com/inject": "false",
+			},
 			Annotations: map[string]string{},
 		},
 	}

--- a/pkg/manifests/common_test.go
+++ b/pkg/manifests/common_test.go
@@ -67,6 +67,27 @@ func TestNamespaceResources(t *testing.T) {
 	}
 }
 
+func TestNamespaceExcludesDynatrace(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		conf *config.Config
+	}{
+		{name: "osm enabled", conf: &config.Config{}},
+		{name: "osm disabled", conf: &config.Config{DisableOSM: true}},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
+			ns := Namespace(c.conf, "app-routing-system")
+			require.Equal(t, "false", ns.Labels["dynatrace.com/inject"], "namespace must opt out of Dynatrace injection")
+		})
+	}
+}
+
 func TestHasTopLevelLabels(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/manifests/fixtures/common/another-namespace.yaml
+++ b/pkg/manifests/fixtures/common/another-namespace.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: another-test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/common/namespace.yaml
+++ b/pkg/manifests/fixtures/common/namespace.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/external_dns/all-possibilities.yaml
+++ b/pkg/manifests/fixtures/external_dns/all-possibilities.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/external_dns/full.yaml
+++ b/pkg/manifests/fixtures/external_dns/full.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/external_dns/gateway-and-ingress-crd.yaml
+++ b/pkg/manifests/fixtures/external_dns/gateway-and-ingress-crd.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/external_dns/gateway-and-ingress-namespace-scoped-crd.yaml
+++ b/pkg/manifests/fixtures/external_dns/gateway-and-ingress-namespace-scoped-crd.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/external_dns/gateway-crd.yaml
+++ b/pkg/manifests/fixtures/external_dns/gateway-crd.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/external_dns/gateway-namespace-scoped-crd.yaml
+++ b/pkg/manifests/fixtures/external_dns/gateway-namespace-scoped-crd.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/external_dns/ingress-crd.yaml
+++ b/pkg/manifests/fixtures/external_dns/ingress-crd.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/external_dns/no-ownership.yaml
+++ b/pkg/manifests/fixtures/external_dns/no-ownership.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/external_dns/private-gateway.yaml
+++ b/pkg/manifests/fixtures/external_dns/private-gateway.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/external_dns/private-ingress-gateway.yaml
+++ b/pkg/manifests/fixtures/external_dns/private-ingress-gateway.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/external_dns/private.yaml
+++ b/pkg/manifests/fixtures/external_dns/private.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/external_dns/short-sync-interval.yaml
+++ b/pkg/manifests/fixtures/external_dns/short-sync-interval.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/dalec/default_version/full-with-client-ip-logging-and-custom-log-format.yaml
+++ b/pkg/manifests/fixtures/nginx/dalec/default_version/full-with-client-ip-logging-and-custom-log-format.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/dalec/default_version/full-with-client-ip-logging.yaml
+++ b/pkg/manifests/fixtures/nginx/dalec/default_version/full-with-client-ip-logging.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/dalec/default_version/full-with-custom-log-format.yaml
+++ b/pkg/manifests/fixtures/nginx/dalec/default_version/full-with-custom-log-format.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/dalec/default_version/full-with-http-disabled.yaml
+++ b/pkg/manifests/fixtures/nginx/dalec/default_version/full-with-http-disabled.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/dalec/default_version/full-with-no-source-ranges.yaml
+++ b/pkg/manifests/fixtures/nginx/dalec/default_version/full-with-no-source-ranges.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/dalec/default_version/full-with-other-ip-source-ranges.yaml
+++ b/pkg/manifests/fixtures/nginx/dalec/default_version/full-with-other-ip-source-ranges.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/dalec/default_version/full-with-replicas.yaml
+++ b/pkg/manifests/fixtures/nginx/dalec/default_version/full-with-replicas.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/dalec/default_version/full-with-ssl-passthrough.yaml
+++ b/pkg/manifests/fixtures/nginx/dalec/default_version/full-with-ssl-passthrough.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/dalec/default_version/full-with-target-cpu.yaml
+++ b/pkg/manifests/fixtures/nginx/dalec/default_version/full-with-target-cpu.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/dalec/default_version/full.yaml
+++ b/pkg/manifests/fixtures/nginx/dalec/default_version/full.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/dalec/default_version/internal-with-custom-http-errors-cert-and-service.yaml
+++ b/pkg/manifests/fixtures/nginx/dalec/default_version/internal-with-custom-http-errors-cert-and-service.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/dalec/default_version/internal-with-custom-http-errors.yaml
+++ b/pkg/manifests/fixtures/nginx/dalec/default_version/internal-with-custom-http-errors.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/dalec/default_version/internal-with-default-backend-service-and-ssl-cert.yaml
+++ b/pkg/manifests/fixtures/nginx/dalec/default_version/internal-with-default-backend-service-and-ssl-cert.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/dalec/default_version/internal-with-default-backend-service.yaml
+++ b/pkg/manifests/fixtures/nginx/dalec/default_version/internal-with-default-backend-service.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/dalec/default_version/internal-with-http-disabled.yaml
+++ b/pkg/manifests/fixtures/nginx/dalec/default_version/internal-with-http-disabled.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/dalec/default_version/internal-with-nil-ssl-cert-and-force-ssl.yaml
+++ b/pkg/manifests/fixtures/nginx/dalec/default_version/internal-with-nil-ssl-cert-and-force-ssl.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/dalec/default_version/internal-with-ssl-cert-and-force-ssl.yaml
+++ b/pkg/manifests/fixtures/nginx/dalec/default_version/internal-with-ssl-cert-and-force-ssl.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/dalec/default_version/internal-with-ssl-cert.yaml
+++ b/pkg/manifests/fixtures/nginx/dalec/default_version/internal-with-ssl-cert.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/dalec/default_version/internal.yaml
+++ b/pkg/manifests/fixtures/nginx/dalec/default_version/internal.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/dalec/default_version/no-ownership.yaml
+++ b/pkg/manifests/fixtures/nginx/dalec/default_version/no-ownership.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/dalec/default_version/optional-features-disabled.yaml
+++ b/pkg/manifests/fixtures/nginx/dalec/default_version/optional-features-disabled.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   creationTimestamp: null
+  labels:
+    dynatrace.com/inject: "false"
   name: test-namespace
 spec: {}
 status: {}

--- a/pkg/manifests/fixtures/nginx/dalec/v1.13.9/full-with-client-ip-logging-and-custom-log-format.yaml
+++ b/pkg/manifests/fixtures/nginx/dalec/v1.13.9/full-with-client-ip-logging-and-custom-log-format.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/dalec/v1.13.9/full-with-client-ip-logging.yaml
+++ b/pkg/manifests/fixtures/nginx/dalec/v1.13.9/full-with-client-ip-logging.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/dalec/v1.13.9/full-with-custom-log-format.yaml
+++ b/pkg/manifests/fixtures/nginx/dalec/v1.13.9/full-with-custom-log-format.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/dalec/v1.13.9/full-with-http-disabled.yaml
+++ b/pkg/manifests/fixtures/nginx/dalec/v1.13.9/full-with-http-disabled.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/dalec/v1.13.9/full-with-no-source-ranges.yaml
+++ b/pkg/manifests/fixtures/nginx/dalec/v1.13.9/full-with-no-source-ranges.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/dalec/v1.13.9/full-with-other-ip-source-ranges.yaml
+++ b/pkg/manifests/fixtures/nginx/dalec/v1.13.9/full-with-other-ip-source-ranges.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/dalec/v1.13.9/full-with-replicas.yaml
+++ b/pkg/manifests/fixtures/nginx/dalec/v1.13.9/full-with-replicas.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/dalec/v1.13.9/full-with-ssl-passthrough.yaml
+++ b/pkg/manifests/fixtures/nginx/dalec/v1.13.9/full-with-ssl-passthrough.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/dalec/v1.13.9/full-with-target-cpu.yaml
+++ b/pkg/manifests/fixtures/nginx/dalec/v1.13.9/full-with-target-cpu.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/dalec/v1.13.9/full.yaml
+++ b/pkg/manifests/fixtures/nginx/dalec/v1.13.9/full.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/dalec/v1.13.9/internal-with-custom-http-errors-cert-and-service.yaml
+++ b/pkg/manifests/fixtures/nginx/dalec/v1.13.9/internal-with-custom-http-errors-cert-and-service.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/dalec/v1.13.9/internal-with-custom-http-errors.yaml
+++ b/pkg/manifests/fixtures/nginx/dalec/v1.13.9/internal-with-custom-http-errors.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/dalec/v1.13.9/internal-with-default-backend-service-and-ssl-cert.yaml
+++ b/pkg/manifests/fixtures/nginx/dalec/v1.13.9/internal-with-default-backend-service-and-ssl-cert.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/dalec/v1.13.9/internal-with-default-backend-service.yaml
+++ b/pkg/manifests/fixtures/nginx/dalec/v1.13.9/internal-with-default-backend-service.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/dalec/v1.13.9/internal-with-http-disabled.yaml
+++ b/pkg/manifests/fixtures/nginx/dalec/v1.13.9/internal-with-http-disabled.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/dalec/v1.13.9/internal-with-nil-ssl-cert-and-force-ssl.yaml
+++ b/pkg/manifests/fixtures/nginx/dalec/v1.13.9/internal-with-nil-ssl-cert-and-force-ssl.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/dalec/v1.13.9/internal-with-ssl-cert-and-force-ssl.yaml
+++ b/pkg/manifests/fixtures/nginx/dalec/v1.13.9/internal-with-ssl-cert-and-force-ssl.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/dalec/v1.13.9/internal-with-ssl-cert.yaml
+++ b/pkg/manifests/fixtures/nginx/dalec/v1.13.9/internal-with-ssl-cert.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/dalec/v1.13.9/internal.yaml
+++ b/pkg/manifests/fixtures/nginx/dalec/v1.13.9/internal.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/dalec/v1.13.9/no-ownership.yaml
+++ b/pkg/manifests/fixtures/nginx/dalec/v1.13.9/no-ownership.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/dalec/v1.13.9/optional-features-disabled.yaml
+++ b/pkg/manifests/fixtures/nginx/dalec/v1.13.9/optional-features-disabled.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   creationTimestamp: null
+  labels:
+    dynatrace.com/inject: "false"
   name: test-namespace
 spec: {}
 status: {}

--- a/pkg/manifests/fixtures/nginx/default_version/full-with-client-ip-logging-and-custom-log-format.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/full-with-client-ip-logging-and-custom-log-format.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/default_version/full-with-client-ip-logging.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/full-with-client-ip-logging.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/default_version/full-with-custom-log-format.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/full-with-custom-log-format.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/default_version/full-with-http-disabled.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/full-with-http-disabled.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/default_version/full-with-no-source-ranges.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/full-with-no-source-ranges.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/default_version/full-with-other-ip-source-ranges.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/full-with-other-ip-source-ranges.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/default_version/full-with-replicas.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/full-with-replicas.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/default_version/full-with-ssl-passthrough.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/full-with-ssl-passthrough.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/default_version/full-with-target-cpu.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/full-with-target-cpu.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/default_version/full.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/full.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/default_version/internal-with-custom-http-errors-cert-and-service.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/internal-with-custom-http-errors-cert-and-service.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/default_version/internal-with-custom-http-errors.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/internal-with-custom-http-errors.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/default_version/internal-with-default-backend-service-and-ssl-cert.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/internal-with-default-backend-service-and-ssl-cert.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/default_version/internal-with-default-backend-service.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/internal-with-default-backend-service.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/default_version/internal-with-http-disabled.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/internal-with-http-disabled.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/default_version/internal-with-nil-ssl-cert-and-force-ssl.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/internal-with-nil-ssl-cert-and-force-ssl.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/default_version/internal-with-ssl-cert-and-force-ssl.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/internal-with-ssl-cert-and-force-ssl.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/default_version/internal-with-ssl-cert.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/internal-with-ssl-cert.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/default_version/internal.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/internal.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/default_version/no-ownership.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/no-ownership.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/default_version/optional-features-disabled.yaml
+++ b/pkg/manifests/fixtures/nginx/default_version/optional-features-disabled.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   creationTimestamp: null
+  labels:
+    dynatrace.com/inject: "false"
   name: test-namespace
 spec: {}
 status: {}

--- a/pkg/manifests/fixtures/nginx/v1.13.7/full-with-client-ip-logging-and-custom-log-format.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.13.7/full-with-client-ip-logging-and-custom-log-format.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/v1.13.7/full-with-client-ip-logging.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.13.7/full-with-client-ip-logging.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/v1.13.7/full-with-custom-log-format.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.13.7/full-with-custom-log-format.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/v1.13.7/full-with-http-disabled.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.13.7/full-with-http-disabled.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/v1.13.7/full-with-no-source-ranges.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.13.7/full-with-no-source-ranges.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/v1.13.7/full-with-other-ip-source-ranges.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.13.7/full-with-other-ip-source-ranges.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/v1.13.7/full-with-replicas.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.13.7/full-with-replicas.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/v1.13.7/full-with-ssl-passthrough.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.13.7/full-with-ssl-passthrough.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/v1.13.7/full-with-target-cpu.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.13.7/full-with-target-cpu.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/v1.13.7/full.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.13.7/full.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/v1.13.7/internal-with-custom-http-errors-cert-and-service.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.13.7/internal-with-custom-http-errors-cert-and-service.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/v1.13.7/internal-with-custom-http-errors.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.13.7/internal-with-custom-http-errors.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/v1.13.7/internal-with-default-backend-service-and-ssl-cert.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.13.7/internal-with-default-backend-service-and-ssl-cert.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/v1.13.7/internal-with-default-backend-service.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.13.7/internal-with-default-backend-service.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/v1.13.7/internal-with-http-disabled.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.13.7/internal-with-http-disabled.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/v1.13.7/internal-with-nil-ssl-cert-and-force-ssl.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.13.7/internal-with-nil-ssl-cert-and-force-ssl.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/v1.13.7/internal-with-ssl-cert-and-force-ssl.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.13.7/internal-with-ssl-cert-and-force-ssl.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/v1.13.7/internal-with-ssl-cert.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.13.7/internal-with-ssl-cert.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/v1.13.7/internal.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.13.7/internal.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/v1.13.7/no-ownership.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.13.7/no-ownership.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels:
+    dynatrace.com/inject: "false"
     openservicemesh.io/monitored-by: osm
   name: test-namespace
 spec: {}

--- a/pkg/manifests/fixtures/nginx/v1.13.7/optional-features-disabled.yaml
+++ b/pkg/manifests/fixtures/nginx/v1.13.7/optional-features-disabled.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   creationTimestamp: null
+  labels:
+    dynatrace.com/inject: "false"
   name: test-namespace
 spec: {}
 status: {}


### PR DESCRIPTION
Add the dynatrace.com/inject=false label to namespaces created by the operator so the Dynatrace webhook does not inject monitoring into App Routing pods.

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)
Feature # (details)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Is it a breaking change which will impact consuming tool(s)?

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
