### PR TITLE
feat(default-domain): improve lifecycle logging

### DIFF
--- a/pkg/clients/default-domain/cached_client.go
+++ b/pkg/clients/default-domain/cached_client.go
@@ -73,10 +73,19 @@ func (c *CachedClient) GetTLSCertificate(ctx context.Context) (*TLSCertificate, 
 
 	// Check if we have a valid cached certificate
 	if c.cache != nil && time.Now().Before(c.cacheExp) {
+		c.logger.Info("serving TLS certificate from cache",
+			"expiresAt", c.cacheExp.UTC().Format(time.RFC3339),
+			"validFor", time.Until(c.cacheExp).Truncate(time.Second).String())
 		return c.cache, nil
 	}
 
 	// Cache expired or not present, fetch with lock held to prevent concurrent fetches
+	if c.cache == nil {
+		c.logger.Info("cache empty, fetching TLS certificate")
+	} else {
+		c.logger.Info("cache expired, fetching fresh TLS certificate",
+			"expiredAt", c.cacheExp.UTC().Format(time.RFC3339))
+	}
 	return c.fetchWithRetryLocked(ctx)
 }
 
@@ -120,14 +129,19 @@ func (c *CachedClient) fetchWithRetryLocked(ctx context.Context) (*TLSCertificat
 		if err == nil {
 			// Success! Update cache and reset health tracking
 			ttl := util.Jitter(cacheTTL, jitterRatio)
+			wasUnhealthy := !c.healthy
 			c.cache = cert
 			c.cacheExp = time.Now().Add(ttl)
 			c.consecutiveFails = 0
 			c.healthy = true
 
 			c.logger.Info("updated certificate cache",
-				"ttl", ttl,
-				"expiresAt", c.cacheExp)
+				"attempt", attempt+1,
+				"ttl", ttl.Truncate(time.Second).String(),
+				"expiresAt", c.cacheExp.UTC().Format(time.RFC3339))
+			if wasUnhealthy {
+				c.logger.Info("default domain client recovered and is healthy again")
+			}
 			return cert, nil
 		}
 
@@ -136,26 +150,28 @@ func (c *CachedClient) fetchWithRetryLocked(ctx context.Context) (*TLSCertificat
 			// 404 is a valid state (cert not ready yet), don't mark as unhealthy
 			c.consecutiveFails = 0
 			c.healthy = true
-			c.logger.Info("certificate not found (404), service is reachable")
+			c.logger.Info("certificate not found (404), service is reachable but certificate is not issued yet")
 			return nil, err
 		}
 
 		lastErr = err
 		c.logger.Error(err, "failed to fetch TLS certificate",
 			"attempt", attempt+1,
-			"maxRetries", maxRetries)
+			"maxRetries", maxRetries,
+			"consecutiveFails", c.consecutiveFails+1)
 
 		// Update health on each failed attempt
 		c.consecutiveFails++
-		if c.consecutiveFails >= maxRetries {
+		if c.consecutiveFails >= maxRetries && c.healthy {
 			c.healthy = false
-			c.logger.Error(nil, "client marked unhealthy after consecutive failed attempts",
+			c.logger.Error(nil, "default domain client marked UNHEALTHY after consecutive failed attempts",
 				"consecutiveFails", c.consecutiveFails,
 				"maxRetries", maxRetries)
 		}
 	}
 
 	// All retries failed
+	c.logger.Error(lastErr, "exhausted all retries fetching TLS certificate", "maxRetries", maxRetries)
 	return nil, fmt.Errorf("failed to fetch TLS certificate after %d attempts: %w", maxRetries, lastErr)
 }
 
@@ -163,20 +179,22 @@ func (c *CachedClient) fetchWithRetryLocked(ctx context.Context) (*TLSCertificat
 func (c *CachedClient) refreshLoop() {
 	// Add initial jitter to avoid thundering herd on startup
 	initialDelay := time.Duration(rand.Int63n(int64(initialJitter)))
-	c.logger.Info("starting certificate refresh loop", "initialDelay", initialDelay)
+	c.logger.Info("starting background certificate refresh loop", "initialDelay", initialDelay.Truncate(time.Second).String())
 
 	select {
 	case <-c.ctx.Done():
+		c.logger.Info("certificate refresh loop cancelled before initial fetch")
 		return
 	case <-time.After(initialDelay):
 	}
 
 	// Initial fetch
+	c.logger.Info("performing initial certificate fetch")
 	c.mu.Lock()
 	_, err := c.fetchWithRetryLocked(c.ctx)
 	c.mu.Unlock()
 	if err != nil {
-		c.logger.Error(err, "initial certificate fetch failed")
+		c.logger.Error(err, "initial certificate fetch failed, will retry on next refresh")
 	}
 
 	// Periodic refresh
@@ -195,18 +213,21 @@ func (c *CachedClient) refreshLoop() {
 			waitDuration = 0
 		}
 
-		c.logger.Info("scheduling next certificate refresh", "wait", waitDuration)
+		c.logger.Info("scheduling next background certificate refresh",
+			"wait", waitDuration.Truncate(time.Second).String(),
+			"refreshAt", nextRefresh.UTC().Format(time.RFC3339))
 
 		select {
 		case <-c.ctx.Done():
-			c.logger.Info("stopping certificate refresh loop")
+			c.logger.Info("stopping background certificate refresh loop")
 			return
 		case <-time.After(waitDuration):
+			c.logger.Info("performing scheduled background certificate refresh")
 			c.mu.Lock()
 			_, err := c.fetchWithRetryLocked(c.ctx)
 			c.mu.Unlock()
 			if err != nil {
-				c.logger.Error(err, "periodic certificate refresh failed")
+				c.logger.Error(err, "scheduled background certificate refresh failed")
 			}
 		}
 	}

--- a/pkg/clients/default-domain/client.go
+++ b/pkg/clients/default-domain/client.go
@@ -30,14 +30,19 @@ func NewClient(opts Opts, logger logr.Logger) *Client {
 	return &Client{
 		opts:       opts,
 		httpClient: &http.Client{},
-		logger:     logger,
+		// tag every log line from this client with the server it's talking to so
+		// the source of a fetch is unambiguous when reading logs.
+		logger: logger.WithValues("serverAddress", opts.ServerAddress),
 	}
 }
 
 // GetTLSCertificate retrieves a TLS certificate from the configured server address
 func (c *Client) GetTLSCertificate(ctx context.Context) (*TLSCertificate, error) {
+	c.logger.Info("requesting TLS certificate from default domain service")
+
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.opts.ServerAddress, nil)
 	if err != nil {
+		c.logger.Error(err, "failed to build request to default domain service")
 		return nil, fmt.Errorf("creating request: %w", err)
 	}
 
@@ -47,18 +52,23 @@ func (c *Client) GetTLSCertificate(ctx context.Context) (*TLSCertificate, error)
 	if err != nil {
 		metrics.DefaultDomainClientCallsTotal.WithLabelValues(metrics.LabelError).Inc()
 		metrics.DefaultDomainClientErrors.Inc()
+		c.logger.Error(err, "request to default domain service failed (could not reach service)")
 		return nil, fmt.Errorf("executing request: %w", err)
 	}
 	defer resp.Body.Close()
+
+	c.logger.Info("received response from default domain service", "statusCode", resp.StatusCode)
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
 		if resp.StatusCode == http.StatusNotFound {
 			metrics.DefaultDomainClientCallsTotal.WithLabelValues(metrics.LabelNotFound).Inc()
+			c.logger.Info("default domain service has no certificate yet (404)", "responseBody", string(body))
 			return nil, &util.NotFoundError{Body: string(body)}
 		}
 		metrics.DefaultDomainClientCallsTotal.WithLabelValues(metrics.LabelError).Inc()
 		metrics.DefaultDomainClientErrors.Inc()
+		c.logger.Error(nil, "default domain service returned unexpected status", "statusCode", resp.StatusCode, "responseBody", string(body))
 		return nil, fmt.Errorf("unexpected status code %d: %s", resp.StatusCode, string(body))
 	}
 
@@ -66,6 +76,7 @@ func (c *Client) GetTLSCertificate(ctx context.Context) (*TLSCertificate, error)
 	if err := json.NewDecoder(resp.Body).Decode(&cert); err != nil {
 		metrics.DefaultDomainClientCallsTotal.WithLabelValues(metrics.LabelError).Inc()
 		metrics.DefaultDomainClientErrors.Inc()
+		c.logger.Error(err, "failed to decode response body from default domain service")
 		return nil, fmt.Errorf("decoding response: %w", err)
 	}
 
@@ -73,12 +84,17 @@ func (c *Client) GetTLSCertificate(ctx context.Context) (*TLSCertificate, error)
 	if cert.ExpiresOn != nil {
 		timeUntilExpiry := time.Until(*cert.ExpiresOn)
 		metrics.DefaultDomainCertExpirySeconds.Set(timeUntilExpiry.Seconds())
-		c.logger.Info("certificate expiry status",
+		c.logger.Info("successfully fetched TLS certificate from default domain service",
+			"certBytes", len(cert.Cert),
+			"keyBytes", len(cert.Key),
 			"expiresOn", cert.ExpiresOn.UTC().Format(time.RFC3339),
 			"timeUntilExpiry", timeUntilExpiry.Truncate(time.Second).String(),
 		)
 	} else {
-		c.logger.Error(nil, "certificate ExpiresOn field is nil, unable to track expiry")
+		c.logger.Error(nil, "successfully fetched TLS certificate but ExpiresOn field is nil, unable to track expiry",
+			"certBytes", len(cert.Cert),
+			"keyBytes", len(cert.Key),
+		)
 	}
 
 	metrics.DefaultDomainClientCallsTotal.WithLabelValues(metrics.LabelSuccess).Inc()

--- a/pkg/controller/defaultdomaincert/default_domain_cert_controller.go
+++ b/pkg/controller/defaultdomaincert/default_domain_cert_controller.go
@@ -89,11 +89,11 @@ func (d *defaultDomainCertControllerReconciler) Reconcile(ctx context.Context, r
 	lgr = lgr.WithValues("secretTarget", *defaultDomainCertificate.Spec.Target.Secret)
 	ctx = log.IntoContext(ctx, lgr)
 
-	lgr.Info("upserting Secret for DefaultDomainCertificate")
+	lgr.Info("generating Secret for DefaultDomainCertificate")
 	secret, certInfo, err := d.generateSecret(ctx, defaultDomainCertificate)
 	if err != nil {
 		if util.IsNotFound(err) {
-			lgr.Info("Default domain certificate not found")
+			lgr.Info("default domain certificate not available yet, requeuing to wait for it to be issued")
 			defaultDomainCertificate.SetCondition(metav1.Condition{
 				Type:    approutingv1alpha1.DefaultDomainCertificateConditionTypeAvailable,
 				Status:  metav1.ConditionFalse,
@@ -106,7 +106,9 @@ func (d *defaultDomainCertControllerReconciler) Reconcile(ctx context.Context, r
 			}
 
 			// we use a Jitter here to avoid thundering herd issues if many DefaultDomainCertificates are waiting for certs
-			return ctrl.Result{RequeueAfter: util.Jitter(30*time.Second, 0.25)}, nil
+			requeueAfter := util.Jitter(30*time.Second, 0.25)
+			lgr.Info("requeuing DefaultDomainCertificate", "requeueAfter", requeueAfter.Truncate(time.Second).String())
+			return ctrl.Result{RequeueAfter: requeueAfter}, nil
 		}
 
 		err := fmt.Errorf("generating Secret for DefaultDomainCertificate: %w", err)
@@ -114,11 +116,20 @@ func (d *defaultDomainCertControllerReconciler) Reconcile(ctx context.Context, r
 		return ctrl.Result{}, err
 	}
 
+	if certInfo != nil {
+		lgr.Info("generated Secret from default domain certificate",
+			"certSubject", certInfo.Subject,
+			"certDNSNames", certInfo.DNSNames,
+			"certNotAfter", certInfo.NotAfter.UTC().Format(time.RFC3339))
+	}
+
+	lgr.Info("upserting Secret for DefaultDomainCertificate")
 	if err := util.Upsert(ctx, d.client, secret); err != nil {
 		d.events.Eventf(defaultDomainCertificate, corev1.EventTypeWarning, "ApplyingCertificateSecretFailed", "Failed to apply Secret for DefaultDomainCertificate: %s", err.Error())
 		lgr.Error(err, "failed to upsert Secret for DefaultDomainCertificate")
 		return ctrl.Result{}, err
 	}
+	lgr.Info("successfully upserted Secret for DefaultDomainCertificate")
 
 	// Update the status of the DefaultDomainCertificate
 	if certInfo != nil && len(certInfo.DNSNames) > 0 {
@@ -135,6 +146,7 @@ func (d *defaultDomainCertControllerReconciler) Reconcile(ctx context.Context, r
 		return ctrl.Result{}, err
 	}
 
+	lgr.Info("DefaultDomainCertificate is Available", "domain", defaultDomainCertificate.Status.Domain)
 	return ctrl.Result{}, nil
 }
 


### PR DESCRIPTION
Add clear logging to the default domain HTTP client, cached client, and certificate reconciler so the fetch/cache/apply flow is easy to follow. Surfaces cache hit/miss, health transitions, response status codes, and certificate details.
