### PR TITLE
clean up default domain dns when off

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -156,6 +156,13 @@ func NewManagerForRestConfig(conf *config.Config, rc *rest.Config) (ctrl.Manager
 		return nil, fmt.Errorf("loading CRDs: %w", err)
 	}
 
+	if !conf.EnableDefaultDomain {
+		if err := dns.CleanDefaultDomainDNS(context.Background(), cl, conf, setupLog); err != nil {
+			setupLog.Error(err, "failed to clean up disabled default domain dns resources")
+			return nil, fmt.Errorf("cleaning up disabled default domain dns resources: %w", err)
+		}
+	}
+
 	if err := setupIndexers(m, setupLog, conf); err != nil {
 		setupLog.Error(err, "unable to setup indexers")
 		return nil, fmt.Errorf("setting up indexers: %w", err)

--- a/pkg/controller/dns/default_domain_cluster_external_dns.go
+++ b/pkg/controller/dns/default_domain_cluster_external_dns.go
@@ -1,12 +1,18 @@
 package dns
 
 import (
+	"context"
+	"fmt"
+
 	approutingv1alpha1 "github.com/Azure/aks-app-routing-operator/api/v1alpha1"
 	"github.com/Azure/aks-app-routing-operator/pkg/config"
 	"github.com/Azure/aks-app-routing-operator/pkg/controller/common"
 	"github.com/Azure/aks-app-routing-operator/pkg/controller/controllername"
 	"github.com/Azure/aks-app-routing-operator/pkg/manifests"
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -20,6 +26,38 @@ const (
 )
 
 var name = controllername.New("default", "domain", "dns")
+
+// CleanDefaultDomainDNS removes the resources created by the default domain DNS reconciler. It's used to tear down
+// the default-domain-dns-external-dns Deployment (and its other resources) when the default domain feature is
+// disabled. Deleting the default-domain-dns ClusterExternalDNS cascades to its owned Deployment via owner references,
+// so without this cleanup the Deployment is orphaned and crash-loops once its DNS zone and identity RBAC are gone.
+func CleanDefaultDomainDNS(ctx context.Context, c client.Client, conf *config.Config, lgr logr.Logger) error {
+	lgr = name.AddToLogger(lgr)
+
+	// Delete the ClusterExternalDNS first so Kubernetes garbage collection removes the owned Deployment/ConfigMap.
+	// We intentionally don't delete the namespace since it's shared with other app routing resources.
+	toDelete := []client.Object{
+		&approutingv1alpha1.ClusterExternalDNS{
+			ObjectMeta: metav1.ObjectMeta{Name: defaultDomainDNSResourceName, Namespace: conf.NS},
+		},
+		&corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{Name: defaultDomainServiceAccountName, Namespace: conf.NS},
+		},
+	}
+
+	for _, obj := range toDelete {
+		lgr := lgr.WithValues("name", obj.GetName(), "namespace", obj.GetNamespace())
+		lgr.Info("deleting disabled default domain dns resource")
+		if err := c.Delete(ctx, obj); err != nil {
+			if k8serrors.IsNotFound(err) || meta.IsNoMatchError(err) {
+				continue
+			}
+			return fmt.Errorf("deleting default domain dns resource %s/%s: %w", obj.GetNamespace(), obj.GetName(), err)
+		}
+	}
+
+	return nil
+}
 
 // NewDefaultDomainDNSReconciler creates a new reconciler for managing external DNS records for the default domain in the cluster.
 func NewDefaultDomainDNSReconciler(

--- a/pkg/controller/dns/default_domain_cluster_external_dns_test.go
+++ b/pkg/controller/dns/default_domain_cluster_external_dns_test.go
@@ -1,15 +1,61 @@
 package dns
 
 import (
+	"context"
 	"testing"
 
 	approutingv1alpha1 "github.com/Azure/aks-app-routing-operator/api/v1alpha1"
 	"github.com/Azure/aks-app-routing-operator/pkg/config"
 	"github.com/Azure/aks-app-routing-operator/pkg/manifests"
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+func TestCleanDefaultDomainDNS(t *testing.T) {
+	const ns = "app-routing-system"
+
+	cedns := &approutingv1alpha1.ClusterExternalDNS{
+		ObjectMeta: metav1.ObjectMeta{Name: defaultDomainDNSResourceName, Namespace: ns},
+	}
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Name: defaultDomainServiceAccountName, Namespace: ns},
+	}
+	// An unrelated resource in the same namespace that must be left untouched.
+	otherSA := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Name: "some-other-sa", Namespace: ns},
+	}
+
+	t.Run("deletes orphaned default domain dns resources", func(t *testing.T) {
+		c := generateDefaultClientBuilder(t, []client.Object{cedns, sa, otherSA}).Build()
+
+		err := CleanDefaultDomainDNS(context.Background(), c, &config.Config{NS: ns}, logr.Discard())
+		require.NoError(t, err)
+
+		// The ClusterExternalDNS and its service account should be gone.
+		gotCEDNS := &approutingv1alpha1.ClusterExternalDNS{}
+		err = c.Get(context.Background(), types.NamespacedName{Name: defaultDomainDNSResourceName, Namespace: ns}, gotCEDNS)
+		require.True(t, k8serrors.IsNotFound(err), "ClusterExternalDNS should be deleted, got err: %v", err)
+
+		gotSA := &corev1.ServiceAccount{}
+		err = c.Get(context.Background(), types.NamespacedName{Name: defaultDomainServiceAccountName, Namespace: ns}, gotSA)
+		require.True(t, k8serrors.IsNotFound(err), "default domain service account should be deleted, got err: %v", err)
+
+		// Unrelated resources must survive.
+		require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "some-other-sa", Namespace: ns}, &corev1.ServiceAccount{}))
+	})
+
+	t.Run("is a no-op when resources are already absent", func(t *testing.T) {
+		c := generateDefaultClientBuilder(t, nil).Build()
+
+		err := CleanDefaultDomainDNS(context.Background(), c, &config.Config{NS: ns}, logr.Discard())
+		require.NoError(t, err)
+	})
+}
 
 func TestDefaultDomainServiceAccount(t *testing.T) {
 	testCases := []struct {


### PR DESCRIPTION
Disabling the default domain feature deletes the Azure DNS zone and revokes the managed identity's RBAC, but left the
default-domain-dns-external-dns Deployment running, so it crash-looped indefinitely on 403 AuthorizationFailed.

When --enable-default-domain is off, delete the orphaned default-domain-dns ClusterExternalDNS (which cascades to its owned Deployment via owner references) and the default-domain-sa ServiceAccount at startup, mirroring the existing removeDisabledCRDs teardown.
