### PR TITLE
fix(ddcert): guard secret upsert and surface failures in status

### DIFF
--- a/pkg/controller/defaultdomaincert/default_domain_cert_controller.go
+++ b/pkg/controller/defaultdomaincert/default_domain_cert_controller.go
@@ -94,13 +94,7 @@ func (d *defaultDomainCertControllerReconciler) Reconcile(ctx context.Context, r
 	if err != nil {
 		if util.IsNotFound(err) {
 			lgr.Info("Default domain certificate not found")
-			defaultDomainCertificate.SetCondition(metav1.Condition{
-				Type:    approutingv1alpha1.DefaultDomainCertificateConditionTypeAvailable,
-				Status:  metav1.ConditionFalse,
-				Reason:  "CertificateNotReady",
-				Message: "Certificate not ready yet, waiting for it to be issued",
-			})
-			if err := d.client.Status().Update(ctx, defaultDomainCertificate); err != nil {
+			if err := d.setUnavailable(ctx, defaultDomainCertificate, "CertificateNotReady", "Certificate not ready yet, waiting for it to be issued"); err != nil {
 				lgr.Error(err, "failed to update status for DefaultDomainCertificate")
 				return ctrl.Result{}, err
 			}
@@ -114,9 +108,36 @@ func (d *defaultDomainCertControllerReconciler) Reconcile(ctx context.Context, r
 		return ctrl.Result{}, err
 	}
 
+	// Refuse to adopt a Secret that App Routing doesn't manage. Overwriting a foreign
+	// Secret can destroy another controller's data, and if its immutable fields (e.g.
+	// type) differ from ours, Upsert fails on every reconcile and the
+	// DefaultDomainCertificate never reports a status. Surface the conflict instead.
+	existing := &corev1.Secret{}
+	switch getErr := d.client.Get(ctx, client.ObjectKeyFromObject(secret), existing); {
+	case getErr == nil && !manifests.HasTopLevelLabels(existing.Labels):
+		msg := fmt.Sprintf("Secret %s/%s already exists and is not managed by App Routing", secret.Namespace, secret.Name)
+		d.events.Eventf(defaultDomainCertificate, corev1.EventTypeWarning, "ConflictingSecretExists", msg)
+		lgr.Info("refusing to overwrite Secret not managed by App Routing")
+		if err := d.setUnavailable(ctx, defaultDomainCertificate, "ConflictingSecretExists", msg); err != nil {
+			lgr.Error(err, "failed to update status for DefaultDomainCertificate")
+			return ctrl.Result{}, err
+		}
+		// Requeue periodically: we don't receive watch events for a Secret we don't
+		// own, so we re-check in case the conflicting Secret is later removed.
+		return ctrl.Result{RequeueAfter: util.Jitter(30*time.Second, 0.25)}, nil
+	case getErr != nil && !apierrors.IsNotFound(getErr):
+		return ctrl.Result{}, fmt.Errorf("checking for existing Secret: %w", getErr)
+	}
+
 	if err := util.Upsert(ctx, d.client, secret); err != nil {
-		d.events.Eventf(defaultDomainCertificate, corev1.EventTypeWarning, "ApplyingCertificateSecretFailed", "Failed to apply Secret for DefaultDomainCertificate: %s", err.Error())
+		msg := fmt.Sprintf("Failed to apply Secret %s/%s for DefaultDomainCertificate: %s", secret.Namespace, secret.Name, err.Error())
+		d.events.Eventf(defaultDomainCertificate, corev1.EventTypeWarning, "ApplyingCertificateSecretFailed", msg)
 		lgr.Error(err, "failed to upsert Secret for DefaultDomainCertificate")
+		// Best-effort: surface the failure on the resource so consumers (and
+		// `kubectl wait`) see why it isn't Available instead of timing out blindly.
+		if statusErr := d.setUnavailable(ctx, defaultDomainCertificate, "ApplyingCertificateSecretFailed", msg); statusErr != nil {
+			lgr.Error(statusErr, "failed to update status for DefaultDomainCertificate")
+		}
 		return ctrl.Result{}, err
 	}
 
@@ -136,6 +157,18 @@ func (d *defaultDomainCertControllerReconciler) Reconcile(ctx context.Context, r
 	}
 
 	return ctrl.Result{}, nil
+}
+
+// setUnavailable marks the DefaultDomainCertificate's Available condition False with the
+// given reason and message so failures are visible on the resource rather than only in logs.
+func (d *defaultDomainCertControllerReconciler) setUnavailable(ctx context.Context, ddc *approutingv1alpha1.DefaultDomainCertificate, reason, message string) error {
+	ddc.SetCondition(metav1.Condition{
+		Type:    approutingv1alpha1.DefaultDomainCertificateConditionTypeAvailable,
+		Status:  metav1.ConditionFalse,
+		Reason:  reason,
+		Message: message,
+	})
+	return d.client.Status().Update(ctx, ddc)
 }
 
 func (d *defaultDomainCertControllerReconciler) generateSecret(ctx context.Context, defaultDomainCertificate *approutingv1alpha1.DefaultDomainCertificate) (*corev1.Secret, *tls.CertificateInfo, error) {

--- a/pkg/controller/defaultdomaincert/default_domain_cert_controller_test.go
+++ b/pkg/controller/defaultdomaincert/default_domain_cert_controller_test.go
@@ -443,14 +443,11 @@ func TestReconcile_FailedToUpsertSecret_RecordsEvent(t *testing.T) {
 	assert.Contains(t, err.Error(), "failed to patch secret")
 	assert.Equal(t, ctrl.Result{}, result)
 
-	// Verify that the warning event was recorded
+	// Verify that the specific warning event was recorded: it must name the
+	// ApplyingCertificateSecretFailed reason, the target Secret, and the underlying error.
 	select {
 	case event := <-fakeRecorder.Events:
-		assert.Contains(t, event, "Warning")
-		assert.Contains(t, event, "ApplyingCertificateSecretFailed")
-		assert.Contains(t, event, "Failed to apply Secret")
-		assert.Contains(t, event, "for DefaultDomainCertificate")
-		assert.Contains(t, event, "failed to patch secret")
+		assert.Equal(t, "Warning ApplyingCertificateSecretFailed Failed to apply Secret "+testNamespace+"/"+testSecretName+" for DefaultDomainCertificate: failed to patch secret", event)
 	case <-time.After(100 * time.Millisecond):
 		t.Fatal("Expected event was not recorded within timeout")
 	}
@@ -574,11 +571,11 @@ func TestReconcile_ConflictingUnmanagedSecret_Refused(t *testing.T) {
 	assert.Equal(t, metav1.ConditionFalse, cond.Status)
 	assert.Equal(t, "ConflictingSecretExists", cond.Reason)
 
-	// A warning event must be recorded.
+	// A specific warning event must be recorded naming the ConflictingSecretExists
+	// reason and the unmanaged Secret it refused to overwrite.
 	select {
 	case event := <-fakeRecorder.Events:
-		assert.Contains(t, event, "Warning")
-		assert.Contains(t, event, "ConflictingSecretExists")
+		assert.Equal(t, "Warning ConflictingSecretExists Secret "+testNamespace+"/"+testSecretName+" already exists and is not managed by App Routing", event)
 	case <-time.After(100 * time.Millisecond):
 		t.Fatal("Expected event was not recorded within timeout")
 	}

--- a/pkg/controller/defaultdomaincert/default_domain_cert_controller_test.go
+++ b/pkg/controller/defaultdomaincert/default_domain_cert_controller_test.go
@@ -448,7 +448,8 @@ func TestReconcile_FailedToUpsertSecret_RecordsEvent(t *testing.T) {
 	case event := <-fakeRecorder.Events:
 		assert.Contains(t, event, "Warning")
 		assert.Contains(t, event, "ApplyingCertificateSecretFailed")
-		assert.Contains(t, event, "Failed to apply Secret for DefaultDomainCertificate")
+		assert.Contains(t, event, "Failed to apply Secret")
+		assert.Contains(t, event, "for DefaultDomainCertificate")
 		assert.Contains(t, event, "failed to patch secret")
 	case <-time.After(100 * time.Millisecond):
 		t.Fatal("Expected event was not recorded within timeout")
@@ -462,11 +463,12 @@ func TestReconcile_SecretAlreadyExists_UpdatesExistingSecret(t *testing.T) {
 
 	ddc := createTestDefaultDomainCertificate("test-ddc", testNamespace, testSecretName)
 
-	// Create an existing secret with different content
+	// Create an existing secret managed by App Routing with different content
 	existingSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      testSecretName,
 			Namespace: testNamespace,
+			Labels:    manifests.GetTopLevelLabels(),
 		},
 		Type: corev1.SecretTypeTLS,
 		Data: map[string][]byte{
@@ -510,6 +512,108 @@ func TestReconcile_SecretAlreadyExists_UpdatesExistingSecret(t *testing.T) {
 	assert.Equal(t, corev1.SecretTypeTLS, secret.Type)
 	assert.Equal(t, []byte(cert), secret.Data["tls.crt"])
 	assert.Equal(t, []byte(key), secret.Data["tls.key"])
+}
+
+func TestReconcile_ConflictingUnmanagedSecret_Refused(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, approutingv1alpha1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	ddc := createTestDefaultDomainCertificate("test-ddc", testNamespace, testSecretName)
+
+	// A pre-existing Secret NOT managed by App Routing (no top-level labels) and with a
+	// different, immutable type. The reconciler must refuse to overwrite it.
+	foreignSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testSecretName,
+			Namespace: testNamespace,
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			"someone-elses-key": []byte("do not touch"),
+		},
+	}
+
+	client := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(ddc, foreignSecret).
+		WithStatusSubresource(ddc).
+		Build()
+
+	cert, key := generateTestCertificate(t)
+	mockClient := newMockDefaultDomainClient(cert, key, nil)
+
+	fakeRecorder := &record.FakeRecorder{Events: make(chan string, 10)}
+	reconciler := &defaultDomainCertControllerReconciler{
+		client:              client,
+		events:              fakeRecorder,
+		conf:                &config.Config{},
+		defaultDomainClient: mockClient,
+	}
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "test-ddc", Namespace: testNamespace}}
+	ctx := context.Background()
+	result, err := reconciler.Reconcile(ctx, req)
+
+	// No error is returned: this is a surfaced conflict, not a controller failure. We
+	// requeue to re-check in case the conflicting Secret is later removed.
+	require.NoError(t, err)
+	assert.NotZero(t, result.RequeueAfter)
+
+	// The foreign Secret must be left untouched.
+	var secret corev1.Secret
+	require.NoError(t, client.Get(ctx, types.NamespacedName{Name: testSecretName, Namespace: testNamespace}, &secret))
+	assert.Equal(t, corev1.SecretTypeOpaque, secret.Type)
+	assert.Equal(t, []byte("do not touch"), secret.Data["someone-elses-key"])
+	assert.NotContains(t, secret.Data, "tls.crt")
+
+	// Status must report the conflict instead of silently timing out.
+	require.NoError(t, client.Get(ctx, types.NamespacedName{Name: ddc.Name, Namespace: ddc.Namespace}, ddc))
+	cond := ddc.GetCondition(v1alpha1.DefaultDomainCertificateConditionTypeAvailable)
+	require.NotNil(t, cond)
+	assert.Equal(t, metav1.ConditionFalse, cond.Status)
+	assert.Equal(t, "ConflictingSecretExists", cond.Reason)
+
+	// A warning event must be recorded.
+	select {
+	case event := <-fakeRecorder.Events:
+		assert.Contains(t, event, "Warning")
+		assert.Contains(t, event, "ConflictingSecretExists")
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("Expected event was not recorded within timeout")
+	}
+}
+
+func TestReconcile_FailedToUpsertSecret_SetsUnavailableStatus(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, approutingv1alpha1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	ddc := createTestDefaultDomainCertificate("test-ddc", testNamespace, testSecretName)
+
+	// Fail only the Secret apply (Patch). The status subresource update must still succeed
+	// so we can assert the failure is surfaced on the resource.
+	base := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ddc).WithStatusSubresource(ddc).Build()
+	errClient := &ErrorClient{Client: base, PatchError: errors.New("failed to patch secret")}
+
+	cert, key := generateTestCertificate(t)
+	mockClient := newMockDefaultDomainClient(cert, key, nil)
+	reconciler := createTestReconciler(errClient, mockClient)
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "test-ddc", Namespace: testNamespace}}
+	ctx := context.Background()
+	result, err := reconciler.Reconcile(ctx, req)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to patch secret")
+	assert.Equal(t, ctrl.Result{}, result)
+
+	// The upsert failure must be reflected on the DefaultDomainCertificate status.
+	require.NoError(t, base.Get(ctx, types.NamespacedName{Name: ddc.Name, Namespace: ddc.Namespace}, ddc))
+	cond := ddc.GetCondition(v1alpha1.DefaultDomainCertificateConditionTypeAvailable)
+	require.NotNil(t, cond)
+	assert.Equal(t, metav1.ConditionFalse, cond.Status)
+	assert.Equal(t, "ApplyingCertificateSecretFailed", cond.Reason)
 }
 
 func TestReconcile_StatusUpdateFails(t *testing.T) {


### PR DESCRIPTION
## Summary

The `DefaultDomainCertificate` reconciler had two gaps that combined into a silent failure:

1. It overwrote **any** Secret at the target name, even one it didn't create.
2. On `util.Upsert` failure it only logged + emitted an event — it never touched the resource's `.status`.

When a pre-existing Secret at the target name had a different **immutable** field (e.g. `type`), `Upsert` failed on every reconcile, the `Available` condition was never set, and `kubectl wait --for=condition=Available` timed out with no signal as to why. This was observed in the wild: the RP-side cert issuance succeeded, but the in-cluster operator looped indefinitely on `Secret "cert" is invalid: type: Invalid value: "kubernetes.io/tls": field is immutable`.

## Changes

- **Ownership guard (managed-by labels):** before upserting, `Get` the target Secret; if it exists and lacks App Routing's top-level labels (`manifests.HasTopLevelLabels`), refuse to overwrite it. Emit a `ConflictingSecretExists` warning event, set `Available=False`, and requeue to re-check (we don't get watch events for Secrets we don't own).
- **Surface upsert failures:** when the upsert itself fails, also set `Available=False` with reason `ApplyingCertificateSecretFailed` (best-effort) so consumers and `kubectl wait` see the failure instead of an empty status. Event messages now include the Secret `namespace/name`.
- Extracted a small `setUnavailable` helper to keep the three `Available=False` paths consistent.

## Behavior change

Adopting a pre-existing **unlabeled** Secret at the target name is now **refused** rather than silently overwritten. If any flow relied on that adoption, this is where it changes.

## Design note

Per Kubernetes convention, the canonical ownership signal is the controller `OwnerReference`, not the `managed-by` label. This PR intentionally uses the label (reusing the existing `HasTopLevelLabels` helper) as the adoption guard. Switching to an ownerRef-based guard (or dropping `client.ForceOwnership` in `util.Upsert`) is a possible follow-up.

## Test plan

- [x] `make unit` (Docker, `go test -race ./...`) — all packages pass
- [x] New: `TestReconcile_ConflictingUnmanagedSecret_Refused` — foreign Secret untouched, status reports conflict, warning event fired, requeued
- [x] New: `TestReconcile_FailedToUpsertSecret_SetsUnavailableStatus` — apply failure sets `Available=False`
- [x] Updated: `TestReconcile_SecretAlreadyExists_UpdatesExistingSecret` — labeled (owned) Secret is still updated