### PR TITLE
Focus gateway e2e shards on gateway suite

### DIFF
--- a/testing/e2e/suites/all.go
+++ b/testing/e2e/suites/all.go
@@ -13,17 +13,27 @@ import (
 // All returns all test in all suites
 func All(infra infra.Provisioned) tests.Ts {
 	t := []test{}
-	t = append(t, basicSuite(infra)...)
-	t = append(t, osmSuite(infra)...)
-	t = append(t, promSuite(infra)...)
-	t = append(t, nicTests(infra)...)
-	t = append(t, externalDnsCrdTests(infra)...)
-	t = append(t, clusterExternalDnsCrdTests(infra)...)
-	t = append(t, defaultBackendTests(infra)...)
-	t = append(t, workloadIdentityTests(infra)...)
-	t = append(t, managedIdentityTests(infra)...)
-	t = append(t, defaultDomainTests(infra)...)
-	t = append(t, gatewayTests(infra)...)
+
+	// Managed Gateway clusters are dedicated shards for Gateway API coverage. Running the
+	// broad ingress/default-backend/NIC matrix on these shards duplicates coverage from
+	// basic/private/osm clusters and dominates runtime before the gateway tests even start.
+	// Keep gateway-capable clusters focused on the Gateway suite so they validate the
+	// managed GatewayClass behavior without repeating the full non-gateway matrix.
+	if getGatewayClassName(infra) != "" {
+		t = append(t, gatewayTests(infra)...)
+	} else {
+		t = append(t, basicSuite(infra)...)
+		t = append(t, osmSuite(infra)...)
+		t = append(t, promSuite(infra)...)
+		t = append(t, nicTests(infra)...)
+		t = append(t, externalDnsCrdTests(infra)...)
+		t = append(t, clusterExternalDnsCrdTests(infra)...)
+		t = append(t, defaultBackendTests(infra)...)
+		t = append(t, workloadIdentityTests(infra)...)
+		t = append(t, managedIdentityTests(infra)...)
+		t = append(t, defaultDomainTests(infra)...)
+	}
+
 	ret := make(tests.Ts, len(t))
 	for i, t := range t {
 		ret[i] = t


### PR DESCRIPTION
## Summary

- Keep managed Gateway clusters focused on the Gateway API suite instead of also running the broad ingress/default-backend/NIC/default-domain matrix.
- Non-gateway clusters continue to run the existing broad suite coverage.
- This avoids duplicating coverage already exercised by basic/private/osm shards and removes most operator redeploy strategies from the gateway shards.

## Runtime impact

In the local full-create validation that picked up this change, the gateway-full-mesh in-cluster strategy list dropped from 23 strategies to 2:

```text
index=0 operatorVersion=latest operatorDeployStrategy=upgrade privateZones=none publicZones=none
index=1 operatorVersion=latest operatorDeployStrategy=cleanDeploy privateZones=none publicZones=none
```

The full-create serial validation results for the runtime branch were:

```text
iteration=1 PASS elapsedSec=5455
iteration=2 PASS elapsedSec=4861
iteration=3 PASS elapsedSec=3522
```

Iteration 3 included this focused-shard change and completed in 58m42s end-to-end, including fresh infra creation/build/deploy. The prior iterations were 91m and 81m.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] `go test ./testing/e2e/... ./cmd/e2e`
- [x] `go run ./cmd/e2e/main.go matrix` with local `GITHUB_OUTPUT`
- [x] Full-create runtime validation picked up this change in iteration 3 and passed

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules