### PR TITLE
Adding Injection to Full Mesh Infra GW E2es

### DIFF
--- a/testing/e2e/manifests/gatewayClientServer.go
+++ b/testing/e2e/manifests/gatewayClientServer.go
@@ -33,9 +33,9 @@ const (
 	// TLSCertServiceAccountOption is the TLS option key for specifying the ServiceAccount for workload identity
 	TLSCertServiceAccountOption = "kubernetes.azure.com/tls-cert-service-account"
 
-	// istioInjectAnnotation is the pod-level Istio annotation that opts a pod out of sidecar
-	// injection even when its namespace is labeled for injection.
-	istioInjectAnnotation = "sidecar.istio.io/inject"
+	// istioInjectLabel is the pod-level Istio label that opts a pod out of sidecar injection
+	// even when its namespace is labeled for injection.
+	istioInjectLabel = "sidecar.istio.io/inject"
 
 	// gatewayBackendPort is the port the test backend service exposes; the route forwards to it.
 	gatewayBackendPort int32 = 8080
@@ -318,8 +318,9 @@ func buildGatewayClient(kind RouteKind, namespace, name, url, nameserver, unreac
 	deployment := newGoDeployment(kind.ClientContents(), namespace, name)
 	// Keep the client out of the mesh: on the full-mesh cluster the namespace is labeled for Istio
 	// injection, but the client must stay sidecar-free since there's no egress gateway to decrypt its
-	// outbound TLS. The annotation is a no-op on non-mesh clusters.
-	deployment.Spec.Template.Annotations[istioInjectAnnotation] = "false"
+	// outbound TLS. The injection webhook's objectSelector matches this label and skips the pod; it's
+	// a no-op on non-mesh clusters.
+	deployment.Spec.Template.Labels[istioInjectLabel] = "false"
 	// gRPC client dials TLS with WithBlock and may also probe an unreachable host; give the
 	// readiness probe more headroom so the kubelet doesn't cancel mid-flight. HTTP is snappier.
 	probeTimeout := int32(5)

--- a/testing/e2e/manifests/gatewayClientServer.go
+++ b/testing/e2e/manifests/gatewayClientServer.go
@@ -33,6 +33,10 @@ const (
 	// TLSCertServiceAccountOption is the TLS option key for specifying the ServiceAccount for workload identity
 	TLSCertServiceAccountOption = "kubernetes.azure.com/tls-cert-service-account"
 
+	// istioInjectAnnotation is the pod-level Istio annotation that opts a pod out of sidecar
+	// injection even when its namespace is labeled for injection.
+	istioInjectAnnotation = "sidecar.istio.io/inject"
+
 	// gatewayBackendPort is the port the test backend service exposes; the route forwards to it.
 	gatewayBackendPort int32 = 8080
 )
@@ -312,6 +316,10 @@ func RouteLabelFilterResourcesFor(kind RouteKind, cfg GatewayLabelFilterTestConf
 // is non-empty, the client also asserts that URL is *not* reachable (used by filter tests).
 func buildGatewayClient(kind RouteKind, namespace, name, url, nameserver, unreachableURL, tlsSecretName string) *appsv1.Deployment {
 	deployment := newGoDeployment(kind.ClientContents(), namespace, name)
+	// Keep the client out of the mesh: on the full-mesh cluster the namespace is labeled for Istio
+	// injection, but the client must stay sidecar-free since there's no egress gateway to decrypt its
+	// outbound TLS. The annotation is a no-op on non-mesh clusters.
+	deployment.Spec.Template.Annotations[istioInjectAnnotation] = "false"
 	// gRPC client dials TLS with WithBlock and may also probe an unreachable host; give the
 	// readiness probe more headroom so the kubelet doesn't cancel mid-flight. HTTP is snappier.
 	probeTimeout := int32(5)

--- a/testing/e2e/suites/gateway.go
+++ b/testing/e2e/suites/gateway.go
@@ -29,6 +29,15 @@ const (
 	zoneTypePrivate
 )
 
+const (
+	// aksIstioSystemNamespace is the namespace where the AKS Istio add-on runs its control plane.
+	aksIstioSystemNamespace = "aks-istio-system"
+	// istioRevLabel is the namespace/pod label that selects an AKS Istio add-on control plane
+	// revision for sidecar injection (e.g. "asm-1-24"). The upstream istio-injection=enabled label
+	// does NOT work for the add-on.
+	istioRevLabel = "istio.io/rev"
+)
+
 func (z zoneType) String() string {
 	switch z {
 	case zoneTypePrivate:
@@ -64,6 +73,9 @@ type multiZoneGatewayTestConfig struct {
 	runNamespaceScoped bool
 	// runFilterTests toggles the gateway and route label selector filter tests for this config.
 	runFilterTests bool
+	// istioRevision is the AKS Istio add-on revision (e.g. "asm-1-24") used to label test
+	// namespaces for sidecar injection. Empty on non-mesh (approuting-istio) clusters.
+	istioRevision string
 }
 
 // gwClusterNs returns the per-zone cluster-scoped gateway namespace.
@@ -94,6 +106,19 @@ func (c multiZoneGatewayTestConfig) gwNsSa() string {
 // deletion before the next kind starts).
 func (c multiZoneGatewayTestConfig) recordPrefix() string {
 	return "zone"
+}
+
+// nsLabels returns the labels for a gateway-test namespace. On the full-mesh cluster it includes
+// the Istio revision label so the add-on injects sidecars into the namespace's workloads; on
+// non-mesh clusters istioRevision is empty and only the managed-by label is applied.
+func (c multiZoneGatewayTestConfig) nsLabels() map[string]string {
+	labels := map[string]string{
+		manifests.ManagedByKey: manifests.ManagedByVal,
+	}
+	if c.istioRevision != "" {
+		labels[istioRevLabel] = c.istioRevision
+	}
+	return labels
 }
 
 // buildGatewayResources builds the gateway+route+client+server resource set for c.routeKind.
@@ -247,6 +272,32 @@ func getGatewayClassName(in infra.Provisioned) string {
 	return ""
 }
 
+// discoverIstioRevision returns the AKS Istio add-on control plane revision (e.g. "asm-1-24") by
+// reading the istiod deployment in the add-on's system namespace. The revision is taken from the
+// deployment's istio.io/rev label, falling back to parsing the "istiod-<revision>" deployment name.
+func discoverIstioRevision(ctx context.Context, config *rest.Config) (string, error) {
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return "", fmt.Errorf("creating kubernetes clientset: %w", err)
+	}
+
+	deployments, err := clientset.AppsV1().Deployments(aksIstioSystemNamespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return "", fmt.Errorf("listing deployments in %s: %w", aksIstioSystemNamespace, err)
+	}
+
+	for _, deploy := range deployments.Items {
+		if rev := deploy.Labels[istioRevLabel]; rev != "" {
+			return rev, nil
+		}
+		if rev, ok := strings.CutPrefix(deploy.Name, "istiod-"); ok && rev != "" {
+			return rev, nil
+		}
+	}
+
+	return "", fmt.Errorf("no istiod deployment found in %s; cannot determine Istio revision", aksIstioSystemNamespace)
+}
+
 func gatewayTests(in infra.Provisioned) []test {
 	// Only run gateway tests on clusters with a managed GatewayClass
 	gwClassName := getGatewayClassName(in)
@@ -318,6 +369,18 @@ func runMultiZoneGatewayTests(ctx context.Context, config *rest.Config, testConf
 		return fmt.Errorf("creating client: %w", err)
 	}
 
+	// On the full-mesh cluster (managed Istio add-on), discover the control plane revision so the
+	// test namespaces can be labeled for sidecar injection. The meshless approuting-istio cluster
+	// has no mesh control plane, so we skip discovery and leave istioRevision empty.
+	if testConfig.gatewayClassName == manifests.IstioGatewayClassName {
+		rev, err := discoverIstioRevision(ctx, config)
+		if err != nil {
+			return fmt.Errorf("discovering istio revision: %w", err)
+		}
+		testConfig.istioRevision = rev
+		lgr.Info("discovered istio add-on revision for sidecar injection", "revision", rev)
+	}
+
 	// ========================================
 	// Test 1: Cluster-scoped ExternalDNS (one namespace per zone)
 	// ========================================
@@ -332,10 +395,8 @@ func runMultiZoneGatewayTests(ctx context.Context, config *rest.Config, testConf
 
 		ns := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: nsName,
-				Labels: map[string]string{
-					manifests.ManagedByKey: manifests.ManagedByVal,
-				},
+				Name:   nsName,
+				Labels: testConfig.nsLabels(),
 			},
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "Namespace",
@@ -444,10 +505,8 @@ func runMultiZoneGatewayTests(ctx context.Context, config *rest.Config, testConf
 
 		ns := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: nsName,
-				Labels: map[string]string{
-					manifests.ManagedByKey: manifests.ManagedByVal,
-				},
+				Name:   nsName,
+				Labels: testConfig.nsLabels(),
 			},
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "Namespace",

--- a/testing/e2e/suites/gateway_filters.go
+++ b/testing/e2e/suites/gateway_filters.go
@@ -584,7 +584,8 @@ func setupClusterScopedFilterNamespaces(ctx context.Context, cl client.Client, t
 		// Create namespace
 		ns := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: nsName,
+				Name:   nsName,
+				Labels: testConfig.nsLabels(),
 			},
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "Namespace",
@@ -625,7 +626,8 @@ func setupNamespaceScopedFilterNamespace(ctx context.Context, cl client.Client, 
 	// Create namespace
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: testConfig.filterNs(),
+			Name:   testConfig.filterNs(),
+			Labels: testConfig.nsLabels(),
 		},
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Namespace",


### PR DESCRIPTION
# Description

Adding sidecar injection to more accurately test traffic path for full-mesh support for dns/tls integration w gwapi.

Fixes # (issue)
Feature # (details)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Is it a breaking change which will impact consuming tool(s)?

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
